### PR TITLE
Add proxy label to output json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ pip-selfcheck.json
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 
 .vscode/*
+
+# ignore patched test files
+test_data/*.patched

--- a/acars_router/README.md
+++ b/acars_router/README.md
@@ -67,6 +67,7 @@ When using environment variables use `;` to separate entries, for example: `AR_S
 | Argument | Environment Variable | Description | Default |
 | -------- | -------------------- | ----------- | --------|
 | `--override-station-name` | `AR_OVERRIDE_STATION_NAME` | Overrides station id/name with this value | |
+| `--add-proxy-id` | `AR_ADD_PROXY_ID` | `AR_ADD_PROXY_ID` | Adds in additional metadata to the output to indicate that `acars_router` proxied the data | `true` |
 
 ### Advanced Settings
 

--- a/acars_router/acars_router.py
+++ b/acars_router/acars_router.py
@@ -1825,7 +1825,7 @@ if __name__ == "__main__":
     parser.add_argument(
         '--add-proxy-id',
         help='Add a proxy id to the JSON message',
-        type=lambda x:bool(strtobool(x)), nargs='?',
+        type=lambda x: bool(strtobool(x)), nargs='?',
         const=True, default=os.getenv("AR_ADD_PROXY_ID", True))
 
     args = parser.parse_args()

--- a/acars_router/acars_router.py
+++ b/acars_router/acars_router.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+from distutils.util import strtobool
 import collections
 import copy
 import json
@@ -1815,11 +1816,16 @@ if __name__ == "__main__":
         default=os.getenv("AR_STATS_FILE", None),
     )
 
+    # Arguement to toggle the output of proxy information
+    # We can't use default argprase bool operations (action=set_true/false) and using the presence
+    # of a flag to toggle behavior from the default
+    # because we need to be able to use an ENV variable to flag the value for running
+    # in Docker.
+
     parser.add_argument(
         '--add-proxy-id',
         help='Add a proxy id to the JSON message',
-        type=bool,
-        default=os.getenv("AR_ADD_PROXY_ID", True)
+        type=lambda x:bool(strtobool(x)), nargs='?', const=True, default=os.getenv("AR_ADD_PROXY_ID", True)
     )
 
     args = parser.parse_args()

--- a/acars_router/acars_router.py
+++ b/acars_router/acars_router.py
@@ -1828,7 +1828,6 @@ if __name__ == "__main__":
         type=lambda x:bool(strtobool(x)), nargs='?',
         const=True, default=os.getenv("AR_ADD_PROXY_ID", True))
 
-
     args = parser.parse_args()
 
     # configure logging: create trace level

--- a/acars_router/acars_router.py
+++ b/acars_router/acars_router.py
@@ -926,7 +926,7 @@ def deduper(
 # OUTPUTTING MESSAGES #
 
 
-def output_queue_populator(in_queue: ARQueue, out_queues: list, protoname: str, station_name_override: str = None):
+def output_queue_populator(in_queue: ARQueue, out_queues: list, protoname: str, station_name_override: str = None, label_proxy: bool = True):
     """
     Puts incoming ACARS/VDLM2 messages into each output queue.
     Intended to be run in a thread.
@@ -955,6 +955,24 @@ def output_queue_populator(in_queue: ARQueue, out_queues: list, protoname: str, 
             if 'vdl2' in data['json']:
                 if 'station' in data['json']['vdl2']:
                     data['json']['vdl2']['station'] = station_name_override
+
+        # label proxy messages
+
+        if label_proxy:
+            # VDLM via dumpvdl2
+            if 'vdl2' in data['json']:
+                if 'app' not in data['json']['vdl2']:
+                    data['json']['vdl2']['app'] = {}
+
+                data['json']['vdl2']['app']['proxied'] = True
+                data['json']['vdl2']['app']['proxied_by'] = "acars_router"
+            # acarsdec **OR** VDLM2 via vdl2dec
+            else:
+                if 'app' not in data['json']:
+                    data['json']['app'] = {}
+
+                data['json']['app']['proxied'] = True
+                data['json']['app']['proxied_by'] = "acars_router"
 
         # serialise json
         data['out_json'] = bytes(
@@ -1796,6 +1814,14 @@ if __name__ == "__main__":
         nargs='?',
         default=os.getenv("AR_STATS_FILE", None),
     )
+
+    parser.add_argument(
+        '--add-proxy-id',
+        help='Add a proxy id to the JSON message',
+        type=bool,
+        default=os.getenv("AR_ADD_PROXY_ID", True)
+    )
+
     args = parser.parse_args()
 
     # configure logging: create trace level
@@ -1965,7 +1991,7 @@ if __name__ == "__main__":
         for _ in range(args.threads_output_queue_populator):
             threading.Thread(
                 target=output_queue_populator,
-                args=(deduped_acars_message_queue, output_acars_queues, "ACARS", args.override_station_name),
+                args=(deduped_acars_message_queue, output_acars_queues, "ACARS", args.override_station_name, args.add_proxy_id),
                 daemon=True,
             ).start()
 
@@ -1973,7 +1999,7 @@ if __name__ == "__main__":
         for _ in range(args.threads_output_queue_populator):
             threading.Thread(
                 target=output_queue_populator,
-                args=(deduped_vdlm2_message_queue, output_vdlm2_queues, "VDLM2", args.override_station_name),
+                args=(deduped_vdlm2_message_queue, output_vdlm2_queues, "VDLM2", args.override_station_name, args.add_proxy_id),
                 daemon=True,
             ).start()
 
@@ -1984,7 +2010,7 @@ if __name__ == "__main__":
         for _ in range(args.threads_output_queue_populator):
             threading.Thread(
                 target=output_queue_populator,
-                args=(hashed_acars_message_queue, output_acars_queues, "ACARS", args.override_station_name),
+                args=(hashed_acars_message_queue, output_acars_queues, "ACARS", args.override_station_name, args.add_proxy_id),
                 daemon=True,
             ).start()
 
@@ -1992,7 +2018,7 @@ if __name__ == "__main__":
         for _ in range(args.threads_output_queue_populator):
             threading.Thread(
                 target=output_queue_populator,
-                args=(hashed_vdlm2_message_queue, output_vdlm2_queues, "VDLM2", args.override_station_name),
+                args=(hashed_vdlm2_message_queue, output_vdlm2_queues, "VDLM2", args.override_station_name, args.add_proxy_id),
                 daemon=True,
             ).start()
 

--- a/acars_router/acars_router.py
+++ b/acars_router/acars_router.py
@@ -1825,7 +1825,8 @@ if __name__ == "__main__":
     parser.add_argument(
         '--add-proxy-id',
         help='Add a proxy id to the JSON message',
-        type=lambda x:bool(strtobool(x)), nargs='?', const=True, default=os.getenv("AR_ADD_PROXY_ID", True)
+        type=lambda x:bool(strtobool(x)), nargs='?',
+        const=True, default=os.getenv("AR_ADD_PROXY_ID", True))
 
 
     args = parser.parse_args()

--- a/test_data/test_tcplisten_tcpsend.sh
+++ b/test_data/test_tcplisten_tcpsend.sh
@@ -9,7 +9,7 @@ socat -d -t5 TCP-LISTEN:"${PORT1}",fork OPEN:/tmp/"$1".tcplisten.tcpsend.out,cre
 sleep 1
 
 # Start acars_router
-python3 ./acars_router/acars_router.py -vv --skew-window 300 --listen-tcp-"$1" "${PORT2}" --send-tcp-"$1" 127.0.0.1:"${PORT1}" &
+python3 ./acars_router/acars_router.py -vv --add-proxy-id=false --skew-window 300 --listen-tcp-"$1" "${PORT2}" --send-tcp-"$1" 127.0.0.1:"${PORT1}" &
 sleep 1
 
 # Send test data thru acars_router

--- a/test_data/test_tcplisten_tcpsend.sh
+++ b/test_data/test_tcplisten_tcpsend.sh
@@ -9,7 +9,7 @@ socat -d -t5 TCP-LISTEN:"${PORT1}",fork OPEN:/tmp/"$1".tcplisten.tcpsend.out,cre
 sleep 1
 
 # Start acars_router
-python3 ./acars_router/acars_router.py -vv --add-proxy-id=false --skew-window 300 --listen-tcp-"$1" "${PORT2}" --send-tcp-"$1" 127.0.0.1:"${PORT1}" &
+python3 ./acars_router/acars_router.py -vv --add-proxy-id false --skew-window 300 --listen-tcp-"$1" "${PORT2}" --send-tcp-"$1" 127.0.0.1:"${PORT1}" &
 sleep 1
 
 # Send test data thru acars_router

--- a/test_data/test_tcpreceive_tcpserve.sh
+++ b/test_data/test_tcpreceive_tcpserve.sh
@@ -4,7 +4,7 @@ PORT1=$(shuf -i 5000-5999 -n 1)
 PORT2=$(shuf -i 6000-6999 -n 1)
 
 # Start acars_router
-timeout 30s python3 ./acars_router/acars_router.py -vv --add-proxy-id=false --skew-window 300 --receive-tcp-"$1"="127.0.0.1:${PORT1}" --serve-tcp-"$1" "${PORT2}" &
+timeout 30s python3 ./acars_router/acars_router.py -vv --add-proxy-id false --skew-window 300 --receive-tcp-"$1"="127.0.0.1:${PORT1}" --serve-tcp-"$1" "${PORT2}" &
 sleep 1
 
 # Start fake destination server for acars_router output

--- a/test_data/test_tcpreceive_tcpserve.sh
+++ b/test_data/test_tcpreceive_tcpserve.sh
@@ -4,7 +4,7 @@ PORT1=$(shuf -i 5000-5999 -n 1)
 PORT2=$(shuf -i 6000-6999 -n 1)
 
 # Start acars_router
-timeout 30s python3 ./acars_router/acars_router.py -vv --skew-window 300 --receive-tcp-"$1"="127.0.0.1:${PORT1}" --serve-tcp-"$1" "${PORT2}" &
+timeout 30s python3 ./acars_router/acars_router.py -vv --add-proxy-id=false --skew-window 300 --receive-tcp-"$1"="127.0.0.1:${PORT1}" --serve-tcp-"$1" "${PORT2}" &
 sleep 1
 
 # Start fake destination server for acars_router output

--- a/test_data/test_udp.sh
+++ b/test_data/test_udp.sh
@@ -9,7 +9,7 @@ socat -d -t5 UDP-LISTEN:"${PORT1}",fork OPEN:/tmp/"$1".udp.out,creat,append &
 sleep 1
 
 # Start acars_router
-python3 ./acars_router/acars_router.py -vv --add-proxy-id=false --skew-window 300 --listen-udp-"$1" "${PORT2}" --send-udp-"$1" 127.0.0.1:"${PORT1}" &
+python3 ./acars_router/acars_router.py -vv --add-proxy-id false --skew-window 300 --listen-udp-"$1" "${PORT2}" --send-udp-"$1" 127.0.0.1:"${PORT1}" &
 sleep 1
 
 # Send test data thru acars_router

--- a/test_data/test_udp.sh
+++ b/test_data/test_udp.sh
@@ -9,7 +9,7 @@ socat -d -t5 UDP-LISTEN:"${PORT1}",fork OPEN:/tmp/"$1".udp.out,creat,append &
 sleep 1
 
 # Start acars_router
-python3 ./acars_router/acars_router.py -vv --skew-window 300 --listen-udp-"$1" "${PORT2}" --send-udp-"$1" 127.0.0.1:"${PORT1}" &
+python3 ./acars_router/acars_router.py -vv --add-proxy-id=false --skew-window 300 --listen-udp-"$1" "${PORT2}" --send-udp-"$1" 127.0.0.1:"${PORT1}" &
 sleep 1
 
 # Send test data thru acars_router

--- a/test_data/test_udp_zmqserver.sh
+++ b/test_data/test_udp_zmqserver.sh
@@ -8,7 +8,7 @@ PORT1=$(shuf -i 7000-7999 -n 1)
 PORT2=$(shuf -i 8000-8999 -n 1)
 
 # Start acars_router
-python3 ./acars_router/acars_router.py -vv --skew-window 300 --listen-udp-"$1" "${PORT2}" --serve-zmq-"$1" "${PORT1}" &
+python3 ./acars_router/acars_router.py -vv --add-proxy-id=false --skew-window 300 --listen-udp-"$1" "${PORT2}" --serve-zmq-"$1" "${PORT1}" &
 sleep 1
 
 # Process to receive output

--- a/test_data/test_udp_zmqserver.sh
+++ b/test_data/test_udp_zmqserver.sh
@@ -8,7 +8,7 @@ PORT1=$(shuf -i 7000-7999 -n 1)
 PORT2=$(shuf -i 8000-8999 -n 1)
 
 # Start acars_router
-python3 ./acars_router/acars_router.py -vv --add-proxy-id=false --skew-window 300 --listen-udp-"$1" "${PORT2}" --serve-zmq-"$1" "${PORT1}" &
+python3 ./acars_router/acars_router.py -vv --add-proxy-id false --skew-window 300 --listen-udp-"$1" "${PORT2}" --serve-zmq-"$1" "${PORT1}" &
 sleep 1
 
 # Process to receive output


### PR DESCRIPTION
Changes to enable the output JSON to include metadata that indicates that it was proxied via `acars_router`. This would be useful for consumers of the data to know the source of the data and help diagnosing issues.

Suggested improvements:
* For `acarsdec` and `vdlm2dec` have the appropriate decoder containers include the `app` field by default and indicate the decoder name / decoder version. No changes necessary to `acars_router` to support this.
* If `acars_router` versions itself (I didn't see anything indicating it did) then that too should be included in the output JSON