### PR TITLE
exit program for uncaught errors in threads / exit program for full queues

### DIFF
--- a/acars_router/acars_router.py
+++ b/acars_router/acars_router.py
@@ -993,7 +993,15 @@ def UDPSender(host, port, output_queues: list, protoname: str):
 
     suppress_errors_until = 0
     suppress_duration = 15
+    sock = None
     while True:
+
+        if sock is not None:
+            try:
+                sock.close()
+            except Exception as e:
+                logger.error(f"socket error: {e}")
+
         # Set up socket
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -1031,8 +1039,6 @@ def UDPSender(host, port, output_queues: list, protoname: str):
 
                 # break inside loop, set up a new socket
                 break
-
-        sock.close()
 
     # clean up
     # remove this instance's queue from the output queue

--- a/acars_router/acars_router.py
+++ b/acars_router/acars_router.py
@@ -40,9 +40,9 @@ class ARQueue(queue.Queue):
 
     def put_or_die(self, item):
         try:
-            self.put(item, timeout = 1)
-        except:
-            logger.error(f"queue full: {self.name}")
+            self.put(item, timeout=1)
+        except queue.Full as e:
+            logger.error(f"queue full: {self.name} {e}")
             sys.stderr.write("acars_router: exiting for FATAL condition: One of the queues is full, this means something is wrong, better start over fresh!\n")
             os._exit(1)
 
@@ -1141,7 +1141,6 @@ def TCPSender(host: str, port: int, output_queues: list, protoname: str):
                 sock.close()
             except Exception as e:
                 logger.error(f"socket error: {e}")
-
 
         now = time.time()
         wait_time = next_reconnect - now

--- a/acars_router/acars_router.py
+++ b/acars_router/acars_router.py
@@ -16,6 +16,7 @@ import uuid
 import zmq
 import signal
 
+global_queue_size = 100
 
 # HELPER CLASSES #
 
@@ -970,7 +971,7 @@ def UDPSender(host, port, output_queues: list, protoname: str):
     # Create an output queue for this instance of the function & add to output queue
     qname = f'output.udp.{protoname}.{host}:{port}'
     logger.debug(f"registering output queue: {qname}")
-    q = ARQueue(qname, 100)
+    q = ARQueue(qname, global_queue_size)
     output_queues.append(q)
 
     suppress_errors_until = 0
@@ -1060,7 +1061,7 @@ def TCPServer(conn: socket.socket, addr: tuple, output_queues: list, protoname: 
     # Create an output queue for this instance of the function & add to output queue
     qname = f'output.tcpserver.{protoname}.{host}:{port}'
     logger.debug(f"registering output queue: {qname}")
-    q = ARQueue(qname, 100)
+    q = ARQueue(qname, global_queue_size)
     output_queues.append(q)
 
     # Set up socket
@@ -1154,7 +1155,7 @@ def TCPSender(host: str, port: int, output_queues: list, protoname: str):
 
         # Create an output queue for this instance of the function & add to output queue
         qname = f'output.tcpclient.{protoname}.{host}:{port}'
-        q = ARQueue(qname, 100)
+        q = ARQueue(qname, global_queue_size)
 
         logger.debug(f"registering output queue: {qname}")
         output_queues.append(q)
@@ -1200,7 +1201,7 @@ def ZMQServer(port: int, output_queues: list, protoname: str):
     # Create an output queue for this instance of the function & add to output queue
     qname = f'output.zmqserver.{protoname}:{port}'
     logger.debug(f"registering output queue: {qname}")
-    q = ARQueue(qname, 100)
+    q = ARQueue(qname, global_queue_size)
     output_queues.append(q)
 
     # Set up zmq context
@@ -1848,27 +1849,27 @@ if __name__ == "__main__":
     COUNTERS.register_queue_list(output_vdlm2_queues)
 
     # define inbound message queues
-    inbound_acars_message_queue = ARQueue('inbound_acars_message_queue', 100)
+    inbound_acars_message_queue = ARQueue('inbound_acars_message_queue', global_queue_size)
     COUNTERS.register_queue(inbound_acars_message_queue)
-    inbound_vdlm2_message_queue = ARQueue('inbound_vdlm2_message_queue', 100)
+    inbound_vdlm2_message_queue = ARQueue('inbound_vdlm2_message_queue', global_queue_size)
     COUNTERS.register_queue(inbound_vdlm2_message_queue)
 
     # define intermediate queue for deserialised messages
-    deserialised_acars_message_queue = ARQueue('deserialised_acars_message_queue', 100)
+    deserialised_acars_message_queue = ARQueue('deserialised_acars_message_queue', global_queue_size)
     COUNTERS.register_queue(deserialised_acars_message_queue)
-    deserialised_vdlm2_message_queue = ARQueue('deserialised_vdlm2_message_queue', 100)
+    deserialised_vdlm2_message_queue = ARQueue('deserialised_vdlm2_message_queue', global_queue_size)
     COUNTERS.register_queue(deserialised_vdlm2_message_queue)
 
     # define intermediate queue for hashed messages
-    hashed_acars_message_queue = ARQueue('hashed_acars_message_queue', 100)
+    hashed_acars_message_queue = ARQueue('hashed_acars_message_queue', global_queue_size)
     COUNTERS.register_queue(hashed_acars_message_queue)
-    hashed_vdlm2_message_queue = ARQueue('hashed_vdlm2_message_queue', 100)
+    hashed_vdlm2_message_queue = ARQueue('hashed_vdlm2_message_queue', global_queue_size)
     COUNTERS.register_queue(hashed_vdlm2_message_queue)
 
     # define intermediate queue for deduped messages
-    deduped_acars_message_queue = ARQueue('deduped_acars_message_queue', 100)
+    deduped_acars_message_queue = ARQueue('deduped_acars_message_queue', global_queue_size)
     COUNTERS.register_queue(deduped_acars_message_queue)
-    deduped_vdlm2_message_queue = ARQueue('deduped_vdlm2_message_queue', 100)
+    deduped_vdlm2_message_queue = ARQueue('deduped_vdlm2_message_queue', global_queue_size)
     COUNTERS.register_queue(deduped_vdlm2_message_queue)
 
     # acars json deserialiser threads


### PR DESCRIPTION
Every started thread is vital for the program to function, an uncaught exception means the thread will exit.
Thus we print the exception and exit the program.

A full queue typically means something is stuck and not processing messages.
Print the name of the full queue and exit the program.