### PR TITLE
Update workflows to get version from Cargo.toml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 .gitattributes
 READMETEMPLATE.md
 README.md
+target

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,3 @@
 .gitattributes
 READMETEMPLATE.md
 README.md
-target

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
           echo "::notice title=${{ github.job }}: Workflow Dispatch Reason::${INPUTS_REASON}"
 
   binary_build:
-    name: Build Binary
+    name: Build Binaries
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,5 +48,6 @@ jobs:
       ghcr_repo: ${{ github.repository }}
       build_with_tmpfs: true
       get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml
+      build_nohealthcheck: false
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,5 +47,6 @@ jobs:
       ghcr_repo_owner: ${{ github.repository_owner }}
       ghcr_repo: ${{ github.repository }}
       build_with_tmpfs: true
+      get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,28 +101,35 @@ jobs:
         run: |
           cargo build --release
 
+      - name: Consolidate binaries
+        run: |
+          mkdir -p ./bin
+          cp -v ./target/release/acars_router ./bin/acars_router.amd64
+          cp -v ./target/armv7-unknown-linux-gnueabihf/release/acars_router ./bin/acars_router.armv7
+          cp -v ./target/aarch64-unknown-linux-gnu/release/acars_router ./bin/acars_router.arm64
+
       - name: Upload artifact amd64 binary
         uses: actions/upload-artifact@v3
         with:
-          name: acars_router_amd64
-          path: target/release/acars_router
+          name: acars_router.amd64
+          path: ./bin/acars_router.amd64
 
       - name: Upload artifact armv7 binary
         uses: actions/upload-artifact@v3
         with:
-          name: acars_router_armv7
-          path: target/armv7-unknown-linux-gnueabihf/release/acars_router
+          name: acars_router.armv7
+          path: ./bin/acars_router.armv7
 
       - name: Upload artifact arm64 binary
         uses: actions/upload-artifact@v3
         with:
-          name: acars_router_arm64
-          path: target/aarch64-unknown-linux-gnu/release/acars_router
+          name: acars_router.arm64
+          path: ./bin/acars_router.arm64
 
       - name: Cache Cargo Build Output
         uses: actions/cache@v3
         with:
-          path: target/
+          path: bin/
           key: ${{ github.run_id }}
 
       # # Allows troubleshooting via SSH
@@ -148,7 +155,7 @@ jobs:
         id: get_cache
         uses: actions/cache@v3
         with:
-          path: target/
+          path: bin/
           key: ${{ github.run_id }}
 
       - name: Check cache
@@ -163,14 +170,10 @@ jobs:
           ORIGDIR=$(pwd)
           # Make release tarballs
           mkdir -vp ./release
-          pushd ./target/release
-          tar cJvf "$ORIGDIR/release/acars_router.amd64.tar.xz" ./acars_router
-          popd
-          pushd ./target/armv7-unknown-linux-gnueabihf/release
-          tar cJvf "$ORIGDIR/release/acars_router.armv7.tar.xz" ./acars_router
-          popd
-          pushd ./target/aarch64-unknown-linux-gnu/release
-          tar cJvf "$ORIGDIR/release/acars_router.arm64.tar.xz" ./acars_router
+          pushd ./bin
+          tar cJvf "$ORIGDIR/release/acars_router.amd64.tar.xz" ./acars_router.amd64
+          tar cJvf "$ORIGDIR/release/acars_router.armv7.tar.xz" ./acars_router.armv7
+          tar cJvf "$ORIGDIR/release/acars_router.arm64.tar.xz" ./acars_router.arm64
           popd
 
       - name: Get binary version from Cargo.toml
@@ -208,7 +211,7 @@ jobs:
       get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml
       build_nohealthcheck: false
       cache_enabled: true
-      cache_path: target/
+      cache_path: bin/
       cache_key: ${{ github.run_id }}
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ on:
       - "**.md"
       - "**.MD"
       - "**.yml"
+      - "**.yaml"
       - "LICENSE"
       - ".gitattributes"
       - ".gitignore"
@@ -38,8 +39,165 @@ jobs:
           echo "Workflow dispatch reason: $INPUTS_REASON"
           echo "::notice title=${{ github.job }}: Workflow Dispatch Reason::${INPUTS_REASON}"
 
+  binary_build:
+    name: Build Binary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "Install OS dependencies: armhf"
+        uses: ryankurte/action-apt@v0.3.0
+        with:
+          arch: armhf
+          packages: "libzmq3-dev:armhf"
+
+      - name: "Install OS dependencies: arm64"
+        uses: ryankurte/action-apt@v0.3.0
+        with:
+          arch: arm64
+          packages: "libzmq3-dev:arm64"
+
+      # i386 currently does not work...
+      # - name: "Install OS dependencies: i386"
+      #   uses: ryankurte/action-apt@v0.3.0
+      #   with:
+      #     arch: i386
+      #     packages: "libzmq3-dev:i386"
+
+      - name: "Install OS dependencies: arm64"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libzmq3-dev
+
+      - name: "Install rust targets/toolchains for cross build"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            g++-arm-linux-gnueabihf \
+            libc6-dev-armhf-cross \
+            g++-aarch64-linux-gnu \
+            libc6-dev-arm64-cross
+
+          rustup target add armv7-unknown-linux-gnueabihf
+          rustup toolchain install stable-armv7-unknown-linux-gnueabihf
+          rustup target add aarch64-unknown-linux-gnu
+          rustup toolchain install stable-aarch64-unknown-linux-gnu
+          rustup target add x86_64-unknown-linux-gnu
+          rustup toolchain install stable-x86_64-unknown-linux-gnu
+
+      - name: Build armv7
+        run: |
+          PKG_CONFIG_SYSROOT_DIR=/usr/arm-linux-gnueabihf RUSTFLAGS="-C linker=/usr/bin/arm-linux-gnueabihf-gcc" cargo build --release --target armv7-unknown-linux-gnueabihf
+
+      - name: Build arm64
+        run: |
+          PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu RUSTFLAGS="-C linker=/usr/bin/aarch64-linux-gnu-gcc" cargo build --release --target aarch64-unknown-linux-gnu
+      
+      - name: Build amd64
+        run: |
+          cargo build --release
+
+      - name: Upload artifact amd64 binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: acars_router_amd64
+          path: target/release/acars_router
+
+      - name: Upload artifact armv7 binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: acars_router_armv7
+          path: target/armv7-unknown-linux-gnueabihf/release/acars_router
+
+      - name: Upload artifact arm64 binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: acars_router_arm64
+          path: target/aarch64-unknown-linux-gnu/release/acars_router
+
+      - name: Cache Cargo Build Output
+        uses: actions/cache@v3
+        with:
+          path: target/
+          key: ${{ github.run_id }}
+
+      # # Allows troubleshooting via SSH
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     limit-access-to-users: mikenye
+  
+  release_binaries:
+    name: Release Binaries
+    needs: [binary_build]
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Cache cargo build output
+        id: get_cache
+        uses: actions/cache@v3
+        with:
+          path: target/
+          key: ${{ github.run_id }}
+
+      - name: Check cache
+        if: steps.get_cache.outputs.cache-hit != 'true'
+        run: |
+          echo "::error title=${{ github.job }}: Could not get binaries from action cache"
+          exit 1
+
+      - name: Prepare binary release tarballs
+        if: steps.get_cache.outputs.cache-hit == 'true'
+        run: |
+          ORIGDIR=$(pwd)
+          # Make release tarballs
+          mkdir -vp ./release
+          pushd ./target/release
+          tar cJvf "$ORIGDIR/release/acars_router.amd64.tar.xz" ./acars_router
+          popd
+          pushd ./target/armv7-unknown-linux-gnueabihf/release
+          tar cJvf "$ORIGDIR/release/acars_router.armv7.tar.xz" ./acars_router
+          popd
+          pushd ./target/aarch64-unknown-linux-gnu/release
+          tar cJvf "$ORIGDIR/release/acars_router.arm64.tar.xz" ./acars_router
+          popd
+
+      - name: Get binary version from Cargo.toml
+        if: steps.get_cache.outputs.cache-hit == 'true'
+        id: release_version
+        run: |
+          # Get version from Cargo.toml
+          RELEASE_VERSION=$(cat Cargo.toml | grep '\[package\]' -A9999 | grep -m 1 'version = ' | tr -d " " | tr -d '"' | tr -d "'" | cut -d = -f 2)
+          echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
+
+      - name: Create tag
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: ${{ steps.release_version.outputs.RELEASE_VERSION }}
+          
+      - name: Create binary release
+        if: steps.get_cache.outputs.cache-hit == 'true'
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ./release/*.tar.xz
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ steps.release_version.outputs.RELEASE_VERSION }}
+          tag: ${{ steps.release_version.outputs.RELEASE_VERSION }}
+
   deploy:
     name: Deploy
+    needs: [binary_build]
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
     with:
       push_enabled: true
@@ -49,5 +207,8 @@ jobs:
       build_with_tmpfs: true
       get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml
       build_nohealthcheck: false
+      cache_enabled: true
+      cache_path: target/
+      cache_key: ${{ github.run_id }}
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -150,23 +150,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libzmq3-dev
 
-      - name: "Install target: armv7-unknown-linux-gnueabihf"
+      - name: "Prepare for multi-arch build"
         run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            g++-arm-linux-gnueabihf \
+            libc6-dev-armhf-cross \
+            g++-aarch64-linux-gnu \
+            libc6-dev-arm64-cross \
+            g++-i686-linux-gnu \
+            libc6-dev-i386-cross
+
           rustup target add armv7-unknown-linux-gnueabihf
           rustup toolchain install stable-armv7-unknown-linux-gnueabihf
-
-      - name: "Install target: aarch64-unknown-linux-gnu"
-        run: |
           rustup target add aarch64-unknown-linux-gnu
           rustup toolchain install stable-aarch64-unknown-linux-gnu
-
-      - name: "Install target: x86_64-unknown-linux-gnu"
-        run: |
           rustup target add x86_64-unknown-linux-gnu
           rustup toolchain install stable-x86_64-unknown-linux-gnu
-
-      - name: "Install target: i686-unknown-linux-gnu"
-        run: |
           rustup target add i686-unknown-linux-gnu
           rustup toolchain install stable-i686-unknown-linux-gnu
 

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -192,11 +192,11 @@ jobs:
       # rustup target add i686-unknown-linux-gnu
       # rustup toolchain install stable-i686-unknown-linux-gnu
 
-      # # Allows troubleshooting via SSH
-      # - name: Setup upterm session
-      #   uses: lhotari/action-upterm@v1
-      #   with:
-      #     limit-access-to-users: mikenye
+      # Allows troubleshooting via SSH
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+        with:
+          limit-access-to-users: mikenye
 
       - name: Build armv7
         run: |

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -156,21 +156,21 @@ jobs:
         uses: ryankurte/action-apt@v0.3.0
         with:
           arch: armhf
-          packages: "libzmq3:armhf"
+          packages: "libzmq3-dev:armhf"
 
       - name: "Install OS dependencies: arm64"
         uses: ryankurte/action-apt@v0.3.0
         with:
           arch: arm64
-          packages: "libzmq3:arm64"
+          packages: "libzmq3-dev:arm64"
 
       - name: "Install OS dependencies: i386"
         uses: ryankurte/action-apt@v0.3.0
         with:
           arch: i386
-          packages: "libzmq3:i386"
+          packages: "libzmq3-dev:i386"
 
-      - name: Install acars_router OS dependencies
+      - name: "Install OS dependencies: arm64"
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -164,11 +164,12 @@ jobs:
           arch: arm64
           packages: "libzmq3-dev:arm64"
 
-      - name: "Install OS dependencies: i386"
-        uses: ryankurte/action-apt@v0.3.0
-        with:
-          arch: i386
-          packages: "libzmq3-dev:i386"
+      # i386 currently does not work...
+      # - name: "Install OS dependencies: i386"
+      #   uses: ryankurte/action-apt@v0.3.0
+      #   with:
+      #     arch: i386
+      #     packages: "libzmq3-dev:i386"
 
       - name: "Install OS dependencies: arm64"
         run: |
@@ -183,9 +184,7 @@ jobs:
             g++-arm-linux-gnueabihf \
             libc6-dev-armhf-cross \
             g++-aarch64-linux-gnu \
-            libc6-dev-arm64-cross \
-            g++-i686-linux-gnu \
-            libc6-dev-i386-cross
+            libc6-dev-arm64-cross
 
           rustup target add armv7-unknown-linux-gnueabihf
           rustup toolchain install stable-armv7-unknown-linux-gnueabihf
@@ -193,8 +192,11 @@ jobs:
           rustup toolchain install stable-aarch64-unknown-linux-gnu
           rustup target add x86_64-unknown-linux-gnu
           rustup toolchain install stable-x86_64-unknown-linux-gnu
-          rustup target add i686-unknown-linux-gnu
-          rustup toolchain install stable-i686-unknown-linux-gnu
+
+      # g++-i686-linux-gnu \
+      # libc6-dev-i386-cross
+      # rustup target add i686-unknown-linux-gnu
+      # rustup toolchain install stable-i686-unknown-linux-gnu
 
       - name: Build armv7
         run: |

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -18,20 +18,7 @@ on:
       - "**.sh"
 
 jobs:
-  flake8-lint:
-    runs-on: ubuntu-latest
-    name: "Linting: flake8"
-    steps:
-      - name: Check out source repository
-        uses: actions/checkout@v3
-      - name: Set up Python environment
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-      - name: flake8 Lint
-        uses: py-actions/flake8@v2
-        with:
-          ignore: "E501"
+  
   hadolint:
     name: "Linting: hadolint"
     runs-on: ubuntu-latest
@@ -73,7 +60,6 @@ jobs:
   test_functionality:
     name: "Test Functionality"
     runs-on: ubuntu-latest
-    needs: flake8-lint
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -232,7 +218,7 @@ jobs:
 
   test_docker_image_build:
     name: Test Docker Image Build
-    needs: [hadolint, flake8-lint, binary_build]
+    needs: [hadolint, binary_build]
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
     with:
       get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -225,12 +225,13 @@ jobs:
   test_docker_image_build:
     name: Test Docker Image Build
     needs: [hadolint, flake8-lint]
+    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
+    with:
+      get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml
+      build_with_tmpfs: true
+      build_nohealthcheck: false
     steps:
-      - uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
-        with:
-          get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml
-          build_with_tmpfs: true
-          build_nohealthcheck: false
+      - run: echo "when is this run"
 
     # strategy:
     #   matrix:

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -123,7 +123,7 @@ jobs:
       #   run: ./test_data/clean_up_after_test.sh vdlm2
 
   binary_build:
-    name: Build Binary
+    name: Build Binaries
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -225,11 +225,12 @@ jobs:
   test_docker_image_build:
     name: Test Docker Image Build
     needs: [hadolint, flake8-lint]
-    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
-    with:
-      get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml
-      build_with_tmpfs: true
-      build_nohealthcheck: false
+    steps:
+      - uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
+        with:
+          get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml
+          build_with_tmpfs: true
+          build_nohealthcheck: false
 
     # strategy:
     #   matrix:

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -216,8 +216,26 @@ jobs:
       #   with:
       #     limit-access-to-users: mikenye
 
-      # TEST RELEASES - WILL MOVE TO DEPLOY.YAML WHEN READY
+  release_binaries:
+    name: Release Binaries
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Cache cargo build output
+        id: get_cache
+        uses: actions/cache@v3
+        with:
+          path: target/
+          key: ${{ github.run_id }}
+
+      - name: Check cache
+        if: steps.get_cache.outputs.cache-hit != 'true'
+        run: |
+          echo "::error title=${{ github.job }}: Could not get binaries from action cache"
+          exit 1
+
       - name: Prepare binary release tarballs
+        if: steps.get_cache.outputs.cache-hit == 'true'
         run: |
           ORIGDIR=$(pwd)
           # Make release tarballs
@@ -233,6 +251,7 @@ jobs:
           popd
 
       - name: Get binary version from Cargo.toml
+        if: steps.get_cache.outputs.cache-hit == 'true'
         id: release_version
         run: |
           # Get version from Cargo.toml
@@ -240,15 +259,16 @@ jobs:
           echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
           
       - name: Create binary release
+        if: steps.get_cache.outputs.cache-hit == 'true'
         uses: ncipollo/release-action@v1
         with:
           artifacts: ./release/*.tar.xz
-          token: ${{ secrets.YOUR_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ steps.release_version.outputs.RELEASE_VERSION }}
 
   test_docker_image_build:
     name: Test Docker Image Build
-    needs: [hadolint, binary_build]
+    needs: [hadolint, binary_build, test_functionality]
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
     with:
       get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml
@@ -257,81 +277,3 @@ jobs:
       cache_enabled: true
       cache_path: target/
       cache_key: ${{ github.run_id }}
-
-    # strategy:
-    #   matrix:
-    #     docker-platform:
-    #       - linux/amd64
-    #       - linux/arm64
-    #       # - linux/arm/v6
-    #       - linux/arm/v7
-    #       - linux/i386
-    # steps:
-    #   # Check out our code
-    #   - name: Checkout
-    #     uses: actions/checkout@v3
-    #     with:
-    #       fetch-depth: 0
-
-    #   # List of files to check to trigger a rebuild on this job
-    #   - name: Get specific changed files
-    #     id: changed-files-specific
-    #     uses: tj-actions/changed-files@v23.2
-    #     with:
-    #       files: |
-    #         Dockerfile
-    #         acars_router
-    #         !*.md
-    #         !*.MD
-
-    #   # https://github.com/marketplace/actions/docker-on-tmpfs
-    #   # https://github.com/rust-lang/cargo/issues/8719
-    #   # https://github.com/rust-lang/cargo/issues/9545
-
-
-
-      # - name: Run Docker on tmpfs
-      #   if: steps.changed-files-specific.outputs.any_changed == 'true'
-      #   uses: JonasAlfredsson/docker-on-tmpfs@v1
-      #   with:
-      #     tmpfs_size: 5
-      #     swap_size: 4
-      #     swap_location: "/mnt/swapfile"
-
-      # # Set up QEMU for multi-arch builds
-      # - name: Set up QEMU
-      #   if: steps.changed-files-specific.outputs.any_changed == 'true'
-      #   uses: docker/setup-qemu-action@v2
-
-      # # Set up buildx for multi platform builds
-      # - name: Set up Docker Buildx
-      #   if: steps.changed-files-specific.outputs.any_changed == 'true'
-      #   id: buildx
-      #   uses: docker/setup-buildx-action@v2
-
-      # # Build
-      # - name: Test Build
-      #   if: steps.changed-files-specific.outputs.any_changed == 'true'
-      #   uses: docker/build-push-action@v3
-      #   with:
-      #     context: .
-      #     file: ./Dockerfile
-      #     no-cache: true
-      #     platforms: ${{ matrix.docker-platform }}
-      #     push: false
-
-      # # Patch dockerfile to remove healthcheck
-      # - name: Patch Dockerfile to remove healthcheck
-      #   if: steps.changed-files-specific.outputs.any_changed == 'true'
-      #   run: sed '/^HEALTHCHECK /d' < Dockerfile > Dockerfile.nohealthcheck
-
-      # # Build nohealthcheck
-      # - name: Test Build nohealthcheck
-      #   if: steps.changed-files-specific.outputs.any_changed == 'true'
-      #   uses: docker/build-push-action@v3
-      #   with:
-      #     context: .
-      #     file: ./Dockerfile.nohealthcheck
-      #     no-cache: true
-      #     platforms: ${{ matrix.docker-platform }}
-      #     push: false

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -216,68 +216,6 @@ jobs:
       #   with:
       #     limit-access-to-users: mikenye
 
-  release_binaries:
-    name: Release Binaries
-    needs: [binary_build]
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Cache cargo build output
-        id: get_cache
-        uses: actions/cache@v3
-        with:
-          path: target/
-          key: ${{ github.run_id }}
-
-      - name: Check cache
-        if: steps.get_cache.outputs.cache-hit != 'true'
-        run: |
-          echo "::error title=${{ github.job }}: Could not get binaries from action cache"
-          exit 1
-
-      - name: Prepare binary release tarballs
-        if: steps.get_cache.outputs.cache-hit == 'true'
-        run: |
-          ORIGDIR=$(pwd)
-          # Make release tarballs
-          mkdir -vp ./release
-          pushd ./target/release
-          tar cJvf "$ORIGDIR/release/acars_router.amd64.tar.xz" ./acars_router
-          popd
-          pushd ./target/armv7-unknown-linux-gnueabihf/release
-          tar cJvf "$ORIGDIR/release/acars_router.armv7.tar.xz" ./acars_router
-          popd
-          pushd ./target/aarch64-unknown-linux-gnu/release
-          tar cJvf "$ORIGDIR/release/acars_router.arm64.tar.xz" ./acars_router
-          popd
-
-      - name: Get binary version from Cargo.toml
-        if: steps.get_cache.outputs.cache-hit == 'true'
-        id: release_version
-        run: |
-          # Get version from Cargo.toml
-          RELEASE_VERSION=$(cat Cargo.toml | grep '\[package\]' -A9999 | grep -m 1 'version = ' | tr -d " " | tr -d '"' | tr -d "'" | cut -d = -f 2)
-          echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
-
-      - name: Create tag
-        uses: rickstaa/action-create-tag@v1
-        with:
-          tag: ${{ steps.release_version.outputs.RELEASE_VERSION }}
-          
-      - name: Create binary release
-        if: steps.get_cache.outputs.cache-hit == 'true'
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: ./release/*.tar.xz
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ steps.release_version.outputs.RELEASE_VERSION }}
-          tag: ${{ steps.release_version.outputs.RELEASE_VERSION }}
-
   test_docker_image_build:
     name: Test Docker Image Build
     needs: [hadolint, binary_build, test_functionality]

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -216,6 +216,9 @@ jobs:
           name: amd64 binary
           path: target/release/acars_router
 
+  test_artifacts:
+    runs-on: ubuntu-latest
+    steps:
       # Allows troubleshooting via SSH
       - name: Setup upterm session
         uses: lhotari/action-upterm@v1

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -146,6 +146,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+        with:
+          limit-access-to-users: mikenye
+
+
       - name: "Prepare for multi-arch build"
         run: |
           sudo rm -rf /var/lib/apt/lists/

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -232,7 +232,7 @@ jobs:
 
   test_docker_image_build:
     name: Test Docker Image Build
-    needs: [hadolint, flake8-lint]
+    needs: [hadolint, flake8-lint, binary_build]
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
     with:
       get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -258,6 +258,11 @@ jobs:
           # Get version from Cargo.toml
           RELEASE_VERSION=$(cat Cargo.toml | grep '\[package\]' -A9999 | grep -m 1 'version = ' | tr -d " " | tr -d '"' | tr -d "'" | cut -d = -f 2)
           echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
+
+      - name: Create tag
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: ${{ steps.release_version.outputs.RELEASE_VERSION }}
           
       - name: Create binary release
         if: steps.get_cache.outputs.cache-hit == 'true'

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -222,9 +222,6 @@ jobs:
           path: target/
           key: ${{ github.run_id }}
 
-  test_artifacts:
-    runs-on: ubuntu-latest
-    steps:
       # Allows troubleshooting via SSH
       - name: Setup upterm session
         uses: lhotari/action-upterm@v1
@@ -241,6 +238,9 @@ jobs:
       get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml
       build_with_tmpfs: true
       build_nohealthcheck: false
+      cache_enabled: true
+      cache_path: target/
+      cache_key: ${{ github.run_id }}
 
     # strategy:
     #   matrix:

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -147,8 +147,8 @@ jobs:
           fetch-depth: 0
       - name: Install deps
         run: |
-          apt-get update
-          apt-get install -y --no-install-recommends libzmq3-dev
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libzmq3-dev
 
       - name: "Install target: armv7-unknown-linux-gnueabihf"
         run: |

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -146,6 +146,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Allows troubleshooting via SSH
       # - name: Setup upterm session
       #   uses: lhotari/action-upterm@v1
       #   with:

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -136,9 +136,8 @@ jobs:
       # - name: Clean up between tests
       #   run: ./test_data/clean_up_after_test.sh vdlm2
 
-  test_binary_build:
-    name: Test Binary Build
-    needs: [flake8-lint]
+  binary_build:
+    name: Build Binary
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -186,11 +185,6 @@ jobs:
           rustup toolchain install stable-aarch64-unknown-linux-gnu
           rustup target add x86_64-unknown-linux-gnu
           rustup toolchain install stable-x86_64-unknown-linux-gnu
-
-      # g++-i686-linux-gnu \
-      # libc6-dev-i386-cross
-      # rustup target add i686-unknown-linux-gnu
-      # rustup toolchain install stable-i686-unknown-linux-gnu
 
       # # Allows troubleshooting via SSH
       # - name: Setup upterm session

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -218,6 +218,7 @@ jobs:
 
   release_binaries:
     name: Release Binaries
+    needs: [binary_build]
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -277,7 +277,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ steps.release_version.outputs.RELEASE_VERSION }}
           tag: ${{ steps.release_version.outputs.RELEASE_VERSION }}
-          commit: ${{ github.run_id }}
 
   test_docker_image_build:
     name: Test Docker Image Build

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -219,6 +219,8 @@ jobs:
       # Allows troubleshooting via SSH
       - name: Setup upterm session
         uses: lhotari/action-upterm@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           limit-access-to-users: mikenye
 

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -184,28 +184,35 @@ jobs:
         run: |
           cargo build --release
 
+      - name: Consolidate binaries
+        run: |
+          mkdir -p ./bin
+          cp -v ./target/release/acars_router ./bin/acars_router.amd64
+          cp -v ./target/armv7-unknown-linux-gnueabihf/release/acars_router ./bin/acars_router.armv7
+          cp -v ./target/aarch64-unknown-linux-gnu/release/acars_router ./bin/acars_router.arm64
+
       - name: Upload artifact amd64 binary
         uses: actions/upload-artifact@v3
         with:
-          name: acars_router_amd64
-          path: target/release/acars_router
+          name: acars_router.amd64
+          path: ./bin/acars_router.amd64
 
       - name: Upload artifact armv7 binary
         uses: actions/upload-artifact@v3
         with:
-          name: acars_router_armv7
-          path: target/armv7-unknown-linux-gnueabihf/release/acars_router
+          name: acars_router.armv7
+          path: ./bin/acars_router.armv7
 
       - name: Upload artifact arm64 binary
         uses: actions/upload-artifact@v3
         with:
-          name: acars_router_arm64
-          path: target/aarch64-unknown-linux-gnu/release/acars_router
+          name: acars_router.arm64
+          path: ./bin/acars_router.arm64
 
       - name: Cache Cargo Build Output
         uses: actions/cache@v3
         with:
-          path: target/
+          path: bin/
           key: ${{ github.run_id }}
 
       # # Allows troubleshooting via SSH
@@ -225,5 +232,5 @@ jobs:
       build_with_tmpfs: true
       build_nohealthcheck: false
       cache_enabled: true
-      cache_path: target/
+      cache_path: bin/
       cache_key: ${{ github.run_id }}

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -146,19 +146,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install dependencies
-        run: |
-          sudo dpkg --add-architecture arm64
-          sudo dpkg --add-architecture armhf
-          sudo dpkg --add-architecture i386
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libzmq3-dev \
-            libzmq3 \
-            libzmq3:arm64 \
-            libzmq3:armhf \
-            libzmq3:i386
-
       - name: "Prepare for multi-arch build"
         run: |
           sudo rm -rf /var/lib/apt/lists/
@@ -179,6 +166,19 @@ jobs:
           rustup toolchain install stable-x86_64-unknown-linux-gnu
           rustup target add i686-unknown-linux-gnu
           rustup toolchain install stable-i686-unknown-linux-gnu
+
+      - name: Install dependencies
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo dpkg --add-architecture armhf
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libzmq3-dev \
+            libzmq3 \
+            libzmq3:arm64 \
+            libzmq3:armhf \
+            libzmq3:i386
 
       - name: Build armv7
         run: |

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -190,21 +190,9 @@ jobs:
         run: |
           PKG_CONFIG_SYSROOT_DIR=/usr/arm-linux-gnueabihf RUSTFLAGS="-C linker=/usr/bin/arm-linux-gnueabihf-gcc" cargo build --release --target armv7-unknown-linux-gnueabihf
 
-      - name: Upload artifact armv7 binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: armv7 binary
-          path: target/armv7-unknown-linux-gnueabihf/release/acars_router
-
       - name: Build arm64
         run: |
           PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu RUSTFLAGS="-C linker=/usr/bin/aarch64-linux-gnu-gcc" cargo build --release --target aarch64-unknown-linux-gnu
-
-      - name: Upload artifact arm64 binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: arm64 binary
-          path: target/aarch64-unknown-linux-gnu/release/acars_router
       
       - name: Build amd64
         run: |
@@ -213,8 +201,26 @@ jobs:
       - name: Upload artifact amd64 binary
         uses: actions/upload-artifact@v3
         with:
-          name: amd64 binary
+          name: acars_router_amd64
           path: target/release/acars_router
+
+      - name: Upload artifact armv7 binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: acars_router_armv7
+          path: target/armv7-unknown-linux-gnueabihf/release/acars_router
+
+      - name: Upload artifact arm64 binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: acars_router_arm64
+          path: target/aarch64-unknown-linux-gnu/release/acars_router
+
+      - name: Cache Cargo Build Output
+        uses: actions/cache@v3
+        with:
+          path: target/
+          key: ${{ github.run_id }}
 
   test_artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -142,6 +142,7 @@ jobs:
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
     with:
       get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml
+      build_nohealthcheck: false
 
     # strategy:
     #   matrix:

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -235,7 +235,8 @@ jobs:
           RELEASE_VERSION=$(cat Cargo.toml | grep '\[package\]' -A9999 | grep -m 1 'version = ' | tr -d " " | tr -d '"' | tr -d "'" | cut -d = -f 2)
           echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
           
-      - uses: ncipollo/release-action@v1
+      - name: Create release
+        uses: ncipollo/release-action@v1
         with:
           artifacts: ./release/*.tar.xz
           token: ${{ secrets.YOUR_GITHUB_TOKEN }}

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -216,6 +216,31 @@ jobs:
       #   with:
       #     limit-access-to-users: mikenye
 
+      # TEST RELEASES - WILL MOVE TO DEPLOY.YAML WHEN READY
+      - name: Prepare release
+        id: prepare_release
+        run: |
+          # Make release tarballs
+          mkdir -vp ./release
+          pushd ./target/release
+          tar cJvf ./release/acars_router.amd64.tar.xz ./acars_router
+          popd
+          pushd ./target/armv7-unknown-linux-gnueabihf/release
+          tar cJvf ./release/acars_router.armv7.tar.xz ./acars_router
+          popd
+          pushd ./target/aarch64-unknown-linux-gnu/release
+          tar cJvf ./release/acars_router.arm64.tar.xz ./acars_router
+          popd
+          # Get version from Cargo.toml
+          RELEASE_VERSION=$(cat Cargo.toml | grep '\[package\]' -A9999 | grep -m 1 'version = ' | tr -d " " | tr -d '"' | tr -d "'" | cut -d = -f 2)
+          echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
+          
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: ./release/*.tar.xz
+          token: ${{ secrets.YOUR_GITHUB_TOKEN }}
+          name: ${{ steps.prepare_release.outputs.RELEASE_VERSION }}
+
   test_docker_image_build:
     name: Test Docker Image Build
     needs: [hadolint, binary_build]

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -217,30 +217,34 @@ jobs:
       #     limit-access-to-users: mikenye
 
       # TEST RELEASES - WILL MOVE TO DEPLOY.YAML WHEN READY
-      - name: Prepare release
-        id: prepare_release
+      - name: Prepare binary release tarballs
         run: |
+          ORIGDIR=$(pwd)
           # Make release tarballs
           mkdir -vp ./release
           pushd ./target/release
-          tar cJvf ./release/acars_router.amd64.tar.xz ./acars_router
+          tar cJvf "$ORIGDIR/release/acars_router.amd64.tar.xz" ./acars_router
           popd
           pushd ./target/armv7-unknown-linux-gnueabihf/release
-          tar cJvf ./release/acars_router.armv7.tar.xz ./acars_router
+          tar cJvf "$ORIGDIR/release/acars_router.armv7.tar.xz" ./acars_router
           popd
           pushd ./target/aarch64-unknown-linux-gnu/release
-          tar cJvf ./release/acars_router.arm64.tar.xz ./acars_router
+          tar cJvf "$ORIGDIR/release/acars_router.arm64.tar.xz" ./acars_router
           popd
+
+      - name: Get binary version from Cargo.toml
+        id: release_version
+        run: |
           # Get version from Cargo.toml
           RELEASE_VERSION=$(cat Cargo.toml | grep '\[package\]' -A9999 | grep -m 1 'version = ' | tr -d " " | tr -d '"' | tr -d "'" | cut -d = -f 2)
           echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
           
-      - name: Create release
+      - name: Create binary release
         uses: ncipollo/release-action@v1
         with:
           artifacts: ./release/*.tar.xz
           token: ${{ secrets.YOUR_GITHUB_TOKEN }}
-          name: ${{ steps.prepare_release.outputs.RELEASE_VERSION }}
+          name: ${{ steps.release_version.outputs.RELEASE_VERSION }}
 
   test_docker_image_build:
     name: Test Docker Image Build

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -192,23 +192,41 @@ jobs:
       # rustup target add i686-unknown-linux-gnu
       # rustup toolchain install stable-i686-unknown-linux-gnu
 
-      # Allows troubleshooting via SSH
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-        with:
-          limit-access-to-users: mikenye
+      # # Allows troubleshooting via SSH
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
+      #   with:
+      #     limit-access-to-users: mikenye
 
       - name: Build armv7
         run: |
-          PKG_CONFIG_SYSROOT_DIR=/usr/arm-linux-gnueabihf cargo build -C linker=arm-linux-gnueabihf-gcc --release --target armv7-unknown-linux-gnueabihf
+          PKG_CONFIG_SYSROOT_DIR=/usr/arm-linux-gnueabihf RUSTFLAGS="-C linker=/usr/bin/arm-linux-gnueabihf-gcc" cargo build --release --target armv7-unknown-linux-gnueabihf
+
+      - name: Upload artifact armv7 binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: armv7 binary
+          path: target/armv7-unknown-linux-gnueabihf/release/acars_router
 
       - name: Build arm64
         run: |
-          PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu cargo build -C linker=aarch64-linux-gnu-gcc --release --target aarch64-unknown-linux-gnu
+          PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu RUSTFLAGS="-C linker=/usr/bin/aarch64-linux-gnu-gcc" cargo build --release --target aarch64-unknown-linux-gnu
+
+      - name: Upload artifact arm64 binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: arm64 binary
+          path: target/aarch64-unknown-linux-gnu/release/acars_router
       
       - name: Build amd64
         run: |
           cargo build --release
+
+      - name: Upload artifact amd64 binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: amd64 binary
+          path: target/release/acars_router
 
   test_docker_image_build:
     name: Test Docker Image Build

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -146,16 +146,38 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
+      #   with:
+      #     limit-access-to-users: mikenye
+
+      - name: "Install OS dependencies: armhf"
+        uses: ryankurte/action-apt@v0.3.0
         with:
-          limit-access-to-users: mikenye
+          arch: armhf
+          packages: "libzmq3:armhf"
 
+      - name: "Install OS dependencies: arm64"
+        uses: ryankurte/action-apt@v0.3.0
+        with:
+          arch: arm64
+          packages: "libzmq3:arm64"
 
-      - name: "Prepare for multi-arch build"
+      - name: "Install OS dependencies: i386"
+        uses: ryankurte/action-apt@v0.3.0
+        with:
+          arch: i386
+          packages: "libzmq3:i386"
+
+      - name: Install acars_router OS dependencies
         run: |
-          sudo rm -rf /var/lib/apt/lists/
-          sudo apt-get update --ignore-missing
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libzmq3-dev
+
+      - name: "Install rust targets/toolchains for cross build"
+        run: |
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             g++-arm-linux-gnueabihf \
             libc6-dev-armhf-cross \
@@ -172,19 +194,6 @@ jobs:
           rustup toolchain install stable-x86_64-unknown-linux-gnu
           rustup target add i686-unknown-linux-gnu
           rustup toolchain install stable-i686-unknown-linux-gnu
-
-      - name: Install dependencies
-        run: |
-          sudo dpkg --add-architecture arm64
-          sudo dpkg --add-architecture armhf
-          sudo dpkg --add-architecture i386
-          sudo apt-get update --ignore-missing
-          sudo apt-get install -y --no-install-recommends \
-            libzmq3-dev \
-            libzmq3 \
-            libzmq3:arm64 \
-            libzmq3:armhf \
-            libzmq3:i386
 
       - name: Build armv7
         run: |

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -222,6 +222,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: Cache cargo build output
         id: get_cache
         uses: actions/cache@v3

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -192,15 +192,23 @@ jobs:
       # rustup target add i686-unknown-linux-gnu
       # rustup toolchain install stable-i686-unknown-linux-gnu
 
-      # Allows troubleshooting via SSH
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-        with:
-          limit-access-to-users: mikenye
+      # # Allows troubleshooting via SSH
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
+      #   with:
+      #     limit-access-to-users: mikenye
 
       - name: Build armv7
         run: |
-          cargo build --target armv7-unknown-linux-gnueabihf
+          PKG_CONFIG_SYSROOT_DIR=/usr/arm-linux-gnueabihf cargo build --release --target armv7-unknown-linux-gnueabihf
+
+      - name: Build arm64
+        run: |
+          PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu cargo build --release --target aarch64-unknown-linux-gnu
+      
+      - name: Build amd64
+        run: |
+          cargo build --release
 
   test_docker_image_build:
     name: Test Docker Image Build

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -136,8 +136,46 @@ jobs:
       # - name: Clean up between tests
       #   run: ./test_data/clean_up_after_test.sh vdlm2
 
-  test_build:
-    name: Test Build
+  test_binary_build:
+    name: Test Binary Build
+    needs: [flake8-lint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install deps
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends libzmq3-dev
+
+      - name: "Install target: armv7-unknown-linux-gnueabihf"
+        run: |
+          rustup target add armv7-unknown-linux-gnueabihf
+          rustup toolchain install stable-armv7-unknown-linux-gnueabihf
+
+      - name: "Install target: aarch64-unknown-linux-gnu"
+        run: |
+          rustup target add aarch64-unknown-linux-gnu
+          rustup toolchain install stable-aarch64-unknown-linux-gnu
+
+      - name: "Install target: x86_64-unknown-linux-gnu"
+        run: |
+          rustup target add x86_64-unknown-linux-gnu
+          rustup toolchain install stable-x86_64-unknown-linux-gnu
+
+      - name: "Install target: i686-unknown-linux-gnu"
+        run: |
+          rustup target add i686-unknown-linux-gnu
+          rustup toolchain install stable-i686-unknown-linux-gnu
+
+      - name: Build armv7
+        run: |
+          cargo build --target armv7-unknown-linux-gnueabihf
+
+  test_docker_image_build:
+    name: Test Docker Image Build
     needs: [hadolint, flake8-lint]
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
     with:

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -200,11 +200,11 @@ jobs:
 
       - name: Build armv7
         run: |
-          PKG_CONFIG_SYSROOT_DIR=/usr/arm-linux-gnueabihf cargo build --release --target armv7-unknown-linux-gnueabihf
+          PKG_CONFIG_SYSROOT_DIR=/usr/arm-linux-gnueabihf cargo build -C linker=arm-linux-gnueabihf-gcc --release --target armv7-unknown-linux-gnueabihf
 
       - name: Build arm64
         run: |
-          PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu cargo build --release --target aarch64-unknown-linux-gnu
+          PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu cargo build -C linker=aarch64-linux-gnu-gcc --release --target aarch64-unknown-linux-gnu
       
       - name: Build amd64
         run: |

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -142,6 +142,7 @@ jobs:
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
     with:
       get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml
+      build_with_tmpfs: true
       build_nohealthcheck: false
 
     # strategy:

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -222,13 +222,13 @@ jobs:
           path: target/
           key: ${{ github.run_id }}
 
-      # Allows troubleshooting via SSH
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          limit-access-to-users: mikenye
+      # # Allows troubleshooting via SSH
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     limit-access-to-users: mikenye
 
   test_docker_image_build:
     name: Test Docker Image Build

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -267,6 +267,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ steps.release_version.outputs.RELEASE_VERSION }}
           tag: ${{ steps.release_version.outputs.RELEASE_VERSION }}
+          commit: ${{ github.run_id }}
 
   test_docker_image_build:
     name: Test Docker Image Build

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -186,12 +186,6 @@ jobs:
           rustup target add x86_64-unknown-linux-gnu
           rustup toolchain install stable-x86_64-unknown-linux-gnu
 
-      # # Allows troubleshooting via SSH
-      # - name: Setup upterm session
-      #   uses: lhotari/action-upterm@v1
-      #   with:
-      #     limit-access-to-users: mikenye
-
       - name: Build armv7
         run: |
           PKG_CONFIG_SYSROOT_DIR=/usr/arm-linux-gnueabihf RUSTFLAGS="-C linker=/usr/bin/arm-linux-gnueabihf-gcc" cargo build --release --target armv7-unknown-linux-gnueabihf
@@ -222,6 +216,12 @@ jobs:
           name: amd64 binary
           path: target/release/acars_router
 
+      # Allows troubleshooting via SSH
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+        with:
+          limit-access-to-users: mikenye
+
   test_docker_image_build:
     name: Test Docker Image Build
     needs: [hadolint, flake8-lint]
@@ -230,8 +230,6 @@ jobs:
       get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml
       build_with_tmpfs: true
       build_nohealthcheck: false
-    steps:
-      - run: echo "when is this run"
 
     # strategy:
     #   matrix:

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -145,10 +145,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libzmq3-dev
 
       - name: "Prepare for multi-arch build"
         run: |
@@ -169,6 +165,19 @@ jobs:
           rustup toolchain install stable-x86_64-unknown-linux-gnu
           rustup target add i686-unknown-linux-gnu
           rustup toolchain install stable-i686-unknown-linux-gnu
+
+      - name: Install dependencies
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo dpkg --add-architecture armhf
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libzmq3-dev \
+            libzmq3 \
+            libzmq3:arm64 \
+            libzmq3:armhf \
+            libzmq3:i386
 
       - name: Build armv7
         run: |

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -138,67 +138,72 @@ jobs:
 
   test_build:
     name: Test Build
-    runs-on: ubuntu-latest
     needs: [hadolint, flake8-lint]
-    strategy:
-      matrix:
-        docker-platform:
-          - linux/amd64
-          - linux/arm64
-          # - linux/arm/v6
-          - linux/arm/v7
-          - linux/i386
-    steps:
-      # Check out our code
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
+    with:
+      get_version_method: cargo_toml_file_in_repo:file=/Cargo.toml
 
-      # List of files to check to trigger a rebuild on this job
-      - name: Get specific changed files
-        id: changed-files-specific
-        uses: tj-actions/changed-files@v23.2
-        with:
-          files: |
-            Dockerfile
-            acars_router
-            !*.md
-            !*.MD
+    # strategy:
+    #   matrix:
+    #     docker-platform:
+    #       - linux/amd64
+    #       - linux/arm64
+    #       # - linux/arm/v6
+    #       - linux/arm/v7
+    #       - linux/i386
+    # steps:
+    #   # Check out our code
+    #   - name: Checkout
+    #     uses: actions/checkout@v3
+    #     with:
+    #       fetch-depth: 0
 
-      # https://github.com/marketplace/actions/docker-on-tmpfs
-      # https://github.com/rust-lang/cargo/issues/8719
-      # https://github.com/rust-lang/cargo/issues/9545
+    #   # List of files to check to trigger a rebuild on this job
+    #   - name: Get specific changed files
+    #     id: changed-files-specific
+    #     uses: tj-actions/changed-files@v23.2
+    #     with:
+    #       files: |
+    #         Dockerfile
+    #         acars_router
+    #         !*.md
+    #         !*.MD
 
-      - name: Run Docker on tmpfs
-        if: steps.changed-files-specific.outputs.any_changed == 'true'
-        uses: JonasAlfredsson/docker-on-tmpfs@v1
-        with:
-          tmpfs_size: 5
-          swap_size: 4
-          swap_location: "/mnt/swapfile"
+    #   # https://github.com/marketplace/actions/docker-on-tmpfs
+    #   # https://github.com/rust-lang/cargo/issues/8719
+    #   # https://github.com/rust-lang/cargo/issues/9545
 
-      # Set up QEMU for multi-arch builds
-      - name: Set up QEMU
-        if: steps.changed-files-specific.outputs.any_changed == 'true'
-        uses: docker/setup-qemu-action@v2
 
-      # Set up buildx for multi platform builds
-      - name: Set up Docker Buildx
-        if: steps.changed-files-specific.outputs.any_changed == 'true'
-        id: buildx
-        uses: docker/setup-buildx-action@v2
 
-      # Build
-      - name: Test Build
-        if: steps.changed-files-specific.outputs.any_changed == 'true'
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          file: ./Dockerfile
-          no-cache: true
-          platforms: ${{ matrix.docker-platform }}
-          push: false
+      # - name: Run Docker on tmpfs
+      #   if: steps.changed-files-specific.outputs.any_changed == 'true'
+      #   uses: JonasAlfredsson/docker-on-tmpfs@v1
+      #   with:
+      #     tmpfs_size: 5
+      #     swap_size: 4
+      #     swap_location: "/mnt/swapfile"
+
+      # # Set up QEMU for multi-arch builds
+      # - name: Set up QEMU
+      #   if: steps.changed-files-specific.outputs.any_changed == 'true'
+      #   uses: docker/setup-qemu-action@v2
+
+      # # Set up buildx for multi platform builds
+      # - name: Set up Docker Buildx
+      #   if: steps.changed-files-specific.outputs.any_changed == 'true'
+      #   id: buildx
+      #   uses: docker/setup-buildx-action@v2
+
+      # # Build
+      # - name: Test Build
+      #   if: steps.changed-files-specific.outputs.any_changed == 'true'
+      #   uses: docker/build-push-action@v3
+      #   with:
+      #     context: .
+      #     file: ./Dockerfile
+      #     no-cache: true
+      #     platforms: ${{ matrix.docker-platform }}
+      #     push: false
 
       # # Patch dockerfile to remove healthcheck
       # - name: Patch Dockerfile to remove healthcheck

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -149,7 +149,7 @@ jobs:
       - name: "Prepare for multi-arch build"
         run: |
           sudo rm -rf /var/lib/apt/lists/
-          sudo apt-get update --fix-missing
+          sudo apt-get update --ignore-missing
           sudo apt-get install -y --no-install-recommends \
             g++-arm-linux-gnueabihf \
             libc6-dev-armhf-cross \
@@ -172,7 +172,7 @@ jobs:
           sudo dpkg --add-architecture arm64
           sudo dpkg --add-architecture armhf
           sudo dpkg --add-architecture i386
-          sudo apt-get update
+          sudo apt-get update --ignore-missing
           sudo apt-get install -y --no-install-recommends \
             libzmq3-dev \
             libzmq3 \

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -266,6 +266,7 @@ jobs:
           artifacts: ./release/*.tar.xz
           token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ steps.release_version.outputs.RELEASE_VERSION }}
+          tag: ${{ steps.release_version.outputs.RELEASE_VERSION }}
 
   test_docker_image_build:
     name: Test Docker Image Build

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -146,9 +146,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install dependencies
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo dpkg --add-architecture armhf
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libzmq3-dev \
+            libzmq3 \
+            libzmq3:arm64 \
+            libzmq3:armhf \
+            libzmq3:i386
+
       - name: "Prepare for multi-arch build"
         run: |
-          sudo apt-get update
+          sudo rm -rf /var/lib/apt/lists/
+          sudo apt-get update --fix-missing
           sudo apt-get install -y --no-install-recommends \
             g++-arm-linux-gnueabihf \
             libc6-dev-armhf-cross \
@@ -165,19 +179,6 @@ jobs:
           rustup toolchain install stable-x86_64-unknown-linux-gnu
           rustup target add i686-unknown-linux-gnu
           rustup toolchain install stable-i686-unknown-linux-gnu
-
-      - name: Install dependencies
-        run: |
-          sudo dpkg --add-architecture arm64
-          sudo dpkg --add-architecture armhf
-          sudo dpkg --add-architecture i386
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libzmq3-dev \
-            libzmq3 \
-            libzmq3:arm64 \
-            libzmq3:armhf \
-            libzmq3:i386
 
       - name: Build armv7
         run: |

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -146,12 +146,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Allows troubleshooting via SSH
-      # - name: Setup upterm session
-      #   uses: lhotari/action-upterm@v1
-      #   with:
-      #     limit-access-to-users: mikenye
-
       - name: "Install OS dependencies: armhf"
         uses: ryankurte/action-apt@v0.3.0
         with:
@@ -197,6 +191,12 @@ jobs:
       # libc6-dev-i386-cross
       # rustup target add i686-unknown-linux-gnu
       # rustup toolchain install stable-i686-unknown-linux-gnu
+
+      # Allows troubleshooting via SSH
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+        with:
+          limit-access-to-users: mikenye
 
       - name: Build armv7
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM rust:1.62-bullseye as builder
-WORKDIR /tmp/acars_router
-# hadolint ignore=DL3008,DL3003,SC1091
-RUN set -x && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends libzmq3-dev
-COPY . .
+# FROM rust:1.62-bullseye as builder
+# WORKDIR /tmp/acars_router
+# # hadolint ignore=DL3008,DL3003,SC1091
+# RUN set -x && \
+#     apt-get update && \
+#     apt-get install -y --no-install-recommends libzmq3-dev
+# COPY . .
 
-RUN cargo build --release
+# RUN cargo build --release
 
 FROM ghcr.io/sdr-enthusiasts/docker-baseimage:base
 
@@ -21,7 +21,12 @@ ENV AR_LISTEN_UDP_ACARS=5550 \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 COPY rootfs /
-COPY --from=builder /tmp/acars_router/target/release/acars_router /opt/acars_router
+# COPY --from=builder /tmp/acars_router/target/release/acars_router /opt/acars_router
+
+COPY target/armv7-unknown-linux-gnueabihf/release/acars_router /opt/acars_router.armv7
+COPY target/aarch64-unknown-linux-gnu/release/acars_router /opt/acars_router.aarch64
+COPY target/release/acars_router /opt/acars_router.x86_64
+
 # hadolint ignore=DL3008,DL3003,SC1091
 RUN set -x && \
     KEPT_PACKAGES=() && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ ENV AR_LISTEN_UDP_ACARS=5550 \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 COPY ./rootfs /
-COPY ./target/armv7-unknown-linux-gnueabihf/release/acars_router /opt/acars_router.armv7
-COPY ./target/aarch64-unknown-linux-gnu/release/acars_router /opt/acars_router.aarch64
-COPY ./target/release/acars_router /opt/acars_router.x86_64
+COPY ./bin/acars_router.armv7 /opt/acars_router.armv7
+COPY ./bin/acars_router.aarch64 /opt/acars_router.aarch64
+COPY ./bin/acars_router.x86_64 /opt/acars_router.x86_64
 
 # hadolint ignore=DL3008,DL3003,SC1091
 RUN set -x && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,12 @@ ENV AR_LISTEN_UDP_ACARS=5550 \
     AR_SERVE_ZMQ_VDLM2=45555
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-COPY rootfs /
+COPY ./rootfs /
 # COPY --from=builder /tmp/acars_router/target/release/acars_router /opt/acars_router
 
-COPY target/armv7-unknown-linux-gnueabihf/release/acars_router /opt/acars_router.armv7
-COPY target/aarch64-unknown-linux-gnu/release/acars_router /opt/acars_router.aarch64
-COPY target/release/acars_router /opt/acars_router.x86_64
+COPY ./target/armv7-unknown-linux-gnueabihf/release/acars_router /opt/acars_router.armv7
+COPY ./target/aarch64-unknown-linux-gnu/release/acars_router /opt/acars_router.aarch64
+COPY ./target/release/acars_router /opt/acars_router.x86_64
 
 # hadolint ignore=DL3008,DL3003,SC1091
 RUN set -x && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ ENV AR_LISTEN_UDP_ACARS=5550 \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 COPY ./rootfs /
 COPY ./bin/acars_router.armv7 /opt/acars_router.armv7
-COPY ./bin/acars_router.aarch64 /opt/acars_router.aarch64
-COPY ./bin/acars_router.x86_64 /opt/acars_router.x86_64
+COPY ./bin/acars_router.arm64 /opt/acars_router.arm64
+COPY ./bin/acars_router.amd64 /opt/acars_router.amd64
 
 # hadolint ignore=DL3008,DL3003,SC1091
 RUN set -x && \
@@ -27,9 +27,9 @@ RUN set -x && \
         && \
     # ensure binaries are executable
     chmod -v a+x \
-        /opt/acars_router.aarch64 \
         /opt/acars_router.armv7 \
-        /opt/acars_router.x86_64 \
+        /opt/acars_router.arm64 \
+        /opt/acars_router.amd64 \
         && \
     # clean up
     apt-get remove -y "${TEMP_PACKAGES[@]}" && \

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,42 @@
+FROM rust:1.62-bullseye as builder
+WORKDIR /tmp/acars_router
+# hadolint ignore=DL3008,DL3003,SC1091
+RUN set -x && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends libzmq3-dev
+COPY . .
+
+RUN cargo build --release
+
+FROM ghcr.io/sdr-enthusiasts/docker-baseimage:base
+
+ENV AR_LISTEN_UDP_ACARS=5550 \
+    AR_LISTEN_TCP_ACARS=5550 \
+    AR_LISTEN_UDP_VDLM2=5555 \
+    AR_LISTEN_TCP_VDLM2=5555 \
+    AR_SERVE_TCP_ACARS=15550 \
+    AR_SERVE_TCP_VDLM2=15555 \
+    AR_SERVE_ZMQ_ACARS=45550 \
+    AR_SERVE_ZMQ_VDLM2=45555
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+COPY rootfs /
+COPY --from=builder /tmp/acars_router/target/release/acars_router /opt/acars_router
+# hadolint ignore=DL3008,DL3003,SC1091
+RUN set -x && \
+    KEPT_PACKAGES=() && \
+    TEMP_PACKAGES=() && \
+    KEPT_PACKAGES+=(libzmq5) && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        "${KEPT_PACKAGES[@]}" \
+        "${TEMP_PACKAGES[@]}"\
+        && \
+    # ensure binaries are executable
+    chmod -v a+x \
+        /opt/acars_router \
+        && \
+    # clean up
+    apt-get remove -y "${TEMP_PACKAGES[@]}" && \
+    apt-get autoremove -y && \
+    rm -rf /src/* /tmp/* /var/lib/apt/lists/*

--- a/rootfs/etc/services.d/acars_router/run
+++ b/rootfs/etc/services.d/acars_router/run
@@ -1,4 +1,17 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-/opt/acars_router
+if /opt/acars_router.x86_64 --version > /dev/null 2>&1; then
+    /opt/acars_router.x86_64
+
+elif /opt/acars_router.aarch64 --version > /dev/null 2>&1; then
+    /opt/acars_router.aarch64
+
+elif /opt/acars_router.armv7 --version > /dev/null 2>&1; then
+    /opt/acars_router.armv7
+
+else
+    >&2 echo "ERROR: Unsupported architecture"
+    sleep 60
+
+fi

--- a/rootfs/etc/services.d/acars_router/run
+++ b/rootfs/etc/services.d/acars_router/run
@@ -10,6 +10,9 @@ elif /opt/acars_router.aarch64 --version > /dev/null 2>&1; then
 elif /opt/acars_router.armv7 --version > /dev/null 2>&1; then
     /opt/acars_router.armv7
 
+elif /opt/acars_router --version /dev/null 2>&1; then
+    /opt/acars_router
+
 else
     >&2 echo "ERROR: Unsupported architecture"
     sleep 60

--- a/rootfs/etc/services.d/acars_router/run
+++ b/rootfs/etc/services.d/acars_router/run
@@ -1,11 +1,11 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-if /opt/acars_router.x86_64 --version > /dev/null 2>&1; then
-    /opt/acars_router.x86_64
+if /opt/acars_router.amd64 --version > /dev/null 2>&1; then
+    /opt/acars_router.amd64
 
-elif /opt/acars_router.aarch64 --version > /dev/null 2>&1; then
-    /opt/acars_router.aarch64
+elif /opt/acars_router.arm64 --version > /dev/null 2>&1; then
+    /opt/acars_router.arm64
 
 elif /opt/acars_router.armv7 --version > /dev/null 2>&1; then
     /opt/acars_router.armv7

--- a/rootfs/etc/services.d/acars_router/run
+++ b/rootfs/etc/services.d/acars_router/run
@@ -10,7 +10,7 @@ elif /opt/acars_router.aarch64 --version > /dev/null 2>&1; then
 elif /opt/acars_router.armv7 --version > /dev/null 2>&1; then
     /opt/acars_router.armv7
 
-elif /opt/acars_router --version /dev/null 2>&1; then
+elif /opt/acars_router --version > /dev/null 2>&1; then
     /opt/acars_router
 
 else

--- a/rootfs/etc/services.d/acars_router/run
+++ b/rootfs/etc/services.d/acars_router/run
@@ -13,5 +13,5 @@ elif /opt/acars_router.armv7 --version > /dev/null 2>&1; then
 else
     >&2 echo "ERROR: Unsupported architecture"
     sleep 60
-
+    exit 1
 fi


### PR DESCRIPTION
Update github workflows to utilise `get_version_method: cargo_toml_file_in_repo` from sdr-enthusiasts/common-github-workflows