### PR TITLE
Rust dev improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ test_data/*.patched
 # Added by cargo
 
 /target
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-clap = { version = "3.2.5", features = ["derive"] }
+clap = { version = "3.2.5", features = ["derive", "env"] }
 log = "0.4.17"
 env_logger = "0.9.0"
 chrono = "0.4.19"

--- a/src/acars_router_servers/listener_servers.rs
+++ b/src/acars_router_servers/listener_servers.rs
@@ -8,7 +8,6 @@
 // NOTE: This is a sender. WE **PUB** to a *SUB* socket.
 
 use crate::generics::OutputServerConfig;
-use crate::helper_functions::should_start_service;
 use crate::tcp_listener_server::TCPListenerServer;
 use crate::tcp_receiver_server::TCPReceiverServer;
 use crate::udp_listener_server::UDPListenerServer;
@@ -19,90 +18,91 @@ use tokio::sync::mpsc::Sender;
 pub fn start_listener_servers(
     config: OutputServerConfig,
     tx_receivers: Sender<serde_json::Value>,
-    server_type: String,
+    server_type: &str,
 ) {
     // Start the UDP listener servers
 
     // Make sure we have at least one UDP port to listen on
-    if should_start_service(config.listen_udp()) {
+    if let Some(listen_udp) = config.listen_udp {
         // Start the UDP listener servers for server_type
         info!("Starting UDP listener servers for {server_type}");
         start_udp_listener_servers(
-            &server_type,
-            config.listen_udp(),
+            server_type,
+            &listen_udp,
             tx_receivers.clone(),
-            config.reassembly_window().clone(),
+            &config.reassembly_window,
         );
     }
 
     // Start the TCP listeners
 
-    if should_start_service(config.listen_tcp()) {
+    if let Some(listen_tcp) = config.listen_tcp {
         // Start the TCP listener servers for server_type
         info!("Starting TCP listener servers for {server_type}");
         start_tcp_listener_servers(
             &server_type,
-            config.listen_tcp(),
+            &listen_tcp,
             tx_receivers.clone(),
-            config.reassembly_window().clone(),
+            &config.reassembly_window,
         );
     }
 
     // Start the ZMQ listeners
 
-    if should_start_service(config.receive_zmq()) {
+    if let Some(receive_zmq) = config.receive_zmq {
         // Start the ZMQ listener servers for {server_type}
         info!("Starting ZMQ Receiver servers for {server_type}");
-        start_zmq_listener_servers(&server_type, config.receive_zmq(), tx_receivers.clone());
+        start_zmq_listener_servers(&server_type, &receive_zmq, tx_receivers.clone());
     }
 
-    if should_start_service(config.receive_tcp()) {
+    if let Some(receive_tcp) = config.receive_tcp {
         info!("Starting TCP Receiver servers for {server_type}");
         start_tcp_receiver_servers(
             &server_type,
-            config.receive_tcp(),
+            &receive_tcp,
             tx_receivers.clone(),
-            config.reassembly_window().clone(),
+            &config.reassembly_window,
         );
     }
 }
 
 fn start_zmq_listener_servers(
-    decoder_type: &String,
-    hosts: &Vec<String>,
+    decoder_type: &str,
+    hosts: &[String],
     channel: Sender<serde_json::Value>,
 ) {
+    let hosts = hosts.to_vec();
     for host in hosts {
         let new_channel = channel.clone();
-        let proto_name = decoder_type.to_string() + "_ZMQ_RECEIVER_" + host;
-        let server_host = host.clone();
+        let proto_name = format!("{}_ZMQ_RECEIVER_{}", decoder_type, host);
+        // let server_host = host.clone();
 
         tokio::spawn(async move {
             let zmq_listener_server = ZMQListnerServer {
-                host: server_host.to_string(),
+                host: host.to_string(),
                 proto_name: proto_name.to_string(),
             };
             match zmq_listener_server.run(new_channel).await {
                 Ok(_) => debug!("{} connection closed", proto_name),
-                Err(e) => error!("{} connection error: {}", proto_name.clone(), e),
+                Err(e) => error!("{} connection error: {:?}", proto_name.clone(), e),
             };
         });
     }
 }
 
 fn start_tcp_listener_servers(
-    decoder_type: &String,
-    ports: &Vec<String>,
+    decoder_type: &str,
+    ports: &[String],
     channel: Sender<serde_json::Value>,
-    reassembly_window: u64,
+    reassembly_window: &u64,
 ) {
     for port in ports {
         let new_channel = channel.clone();
         let server_tcp_port = port.clone();
         let proto_name = decoder_type.to_string() + "_TCP_LISTEN_" + &server_tcp_port;
         let server = TCPListenerServer {
-            proto_name: proto_name,
-            reassembly_window: reassembly_window,
+            proto_name,
+            reassembly_window: *reassembly_window,
         };
 
         debug!(
@@ -114,10 +114,10 @@ fn start_tcp_listener_servers(
 }
 
 fn start_udp_listener_servers(
-    decoder_type: &String,
-    ports: &Vec<String>,
+    decoder_type: &str,
+    ports: &[String],
     channel: Sender<serde_json::Value>,
-    reassembly_window: u64,
+    reassembly_window: &u64,
 ) {
     for udp_port in ports {
         let new_channel = channel.clone();
@@ -126,8 +126,8 @@ fn start_udp_listener_servers(
         let server = UDPListenerServer {
             buf: vec![0; 5000],
             to_send: None,
-            proto_name: proto_name,
-            reassembly_window: reassembly_window,
+            proto_name,
+            reassembly_window: *reassembly_window,
         };
 
         // This starts the server task.
@@ -143,18 +143,18 @@ fn start_tcp_receiver_servers(
     decoder_type: &str,
     hosts: &Vec<String>,
     channel: Sender<serde_json::Value>,
-    reassembly_window: u64,
+    reassembly_window: &u64,
 ) {
     for host in hosts {
         let new_channel = channel.clone();
         let proto_name = decoder_type.to_string() + "_TCP_RECEIVER_" + host;
         let server_host = host.clone();
-
+        let reassembly_window = *reassembly_window;
         tokio::spawn(async move {
             let tcp_receiver_server = TCPReceiverServer {
                 host: server_host.to_string(),
                 proto_name: proto_name.to_string(),
-                reassembly_window: reassembly_window,
+                reassembly_window,
             };
             match tcp_receiver_server.run(new_channel).await {
                 Ok(_) => debug!("{} connection closed", proto_name),

--- a/src/acars_router_servers/sender_servers.rs
+++ b/src/acars_router_servers/sender_servers.rs
@@ -8,7 +8,6 @@
 use crate::generics::{reconnect_options, SenderServer, SenderServerConfig, Shared};
 use crate::tcp_serve_server::TCPServeServer;
 use crate::udp_sender_server::UDPSenderServer;
-use log::{debug, error};
 use serde_json::Value;
 use std::sync::Arc;
 use stubborn_io::StubbornTcpStream;
@@ -81,7 +80,7 @@ pub async fn start_sender_servers(
                     let state = Arc::new(Mutex::new(Shared::new()));
                     tokio::spawn(async move {
                         tcp_sender_server
-                            .watch_for_connections(rx_processed, state)
+                            .watch_for_connections(rx_processed, &state)
                             .await;
                     });
                 }

--- a/src/acars_router_servers/tcp/inputs/tcp_listener_server.rs
+++ b/src/acars_router_servers/tcp/inputs/tcp_listener_server.rs
@@ -9,7 +9,6 @@
 // aka does not connect and then sends the data in to be processed internally
 
 use crate::packet_handler::PacketHandler;
-use log::{debug, error, info, trace};
 use std::error::Error;
 use std::io;
 use std::net::SocketAddr;
@@ -29,30 +28,26 @@ impl TCPListenerServer {
         listen_acars_udp_port: String,
         channel: Sender<serde_json::Value>,
     ) -> Result<(), io::Error> {
-        let TCPListenerServer {
-            proto_name,
-            reassembly_window,
-        } = self;
 
-        let listener = TcpListener::bind(format!("0.0.0.0:{}", listen_acars_udp_port)).await?;
+        let listener: TcpListener = TcpListener::bind(format!("0.0.0.0:{}", listen_acars_udp_port)).await?;
         info!(
             "[TCP Listener SERVER: {}]: Listening on: {}",
-            proto_name,
+            self.proto_name,
             listener.local_addr()?
         );
 
         loop {
             trace!(
                 "[TCP Listener SERVER: {}]: Waiting for connection",
-                proto_name
+                self.proto_name
             );
             // Asynchronously wait for an inbound TcpStream.
             let (stream, addr) = listener.accept().await?;
             let new_channel = channel.clone();
-            let new_proto_name = format!("{}:{}", proto_name, addr);
+            let new_proto_name = format!("{}:{}", self.proto_name, addr);
             info!(
                 "[TCP Listener SERVER: {}]:accepted connection from {}",
-                proto_name, addr
+                self.proto_name, addr
             );
             // Spawn our handler to be run asynchronously.
             tokio::spawn(async move {
@@ -61,7 +56,7 @@ impl TCPListenerServer {
                     &new_proto_name,
                     new_channel,
                     addr,
-                    reassembly_window,
+                    self.reassembly_window,
                 )
                 .await
                 {
@@ -73,7 +68,7 @@ impl TCPListenerServer {
                         "[TCP Listener SERVER: {}] connection error: {}",
                         new_proto_name.clone(),
                         e
-                    ),
+                    )
                 };
             });
         }
@@ -82,14 +77,14 @@ impl TCPListenerServer {
 
 async fn process_tcp_sockets(
     stream: TcpStream,
-    proto_name: &String,
+    proto_name: &str,
     channel: Sender<serde_json::Value>,
     peer: SocketAddr,
     reassembly_window: u64,
 ) -> Result<(), Box<dyn Error>> {
     let mut lines = Framed::new(stream, LinesCodec::new_with_max_length(8000));
 
-    let packet_handler = PacketHandler::new(&proto_name, reassembly_window);
+    let packet_handler = PacketHandler::new(proto_name, reassembly_window);
 
     while let Some(Ok(line)) = lines.next().await {
         let split_messages_by_newline: Vec<&str> = line.split_terminator('\n').collect();
@@ -99,8 +94,7 @@ async fn process_tcp_sockets(
                 msg_by_newline.split_terminator("}{").collect();
 
             for (count, msg_by_brackets) in split_messages_by_brackets.iter().enumerate() {
-                let final_message: String;
-                // FIXME: This feels very non-rust idomatic and is ugly
+                let mut final_message: String = String::new();
 
                 // Our message had no brackets, so we can just send it
                 if split_messages_by_brackets.len() == 1 {
@@ -113,21 +107,21 @@ async fn process_tcp_sockets(
                         "[TCP Listener SERVER: {}] Multiple messages received in a packet.",
                         proto_name
                     );
-                    final_message = format!("{}{}", "}", msg_by_brackets);
+                    final_message = format!("}}{}", msg_by_brackets);
                 } else if count == split_messages_by_brackets.len() - 1 {
                     // This case is for the last element, which should only ever need a single opening bracket
                     trace!(
                         "[TCP Listener SERVER: {}] End of a multiple message packet",
                         proto_name
                     );
-                    final_message = format!("{}{}", "{", msg_by_brackets);
+                    final_message = format!("{{{}", msg_by_brackets);
                 } else {
                     // This case is for any middle elements, which need both an opening and closing bracket
                     trace!(
                         "[TCP Listener SERVER: {}] Middle of a multiple message packet",
                         proto_name
                     );
-                    final_message = format!("{}{}{}", "{", msg_by_brackets, "}");
+                    final_message = format!("{{{}}}", msg_by_brackets);
                 }
                 match packet_handler
                     .attempt_message_reassembly(final_message, peer)

--- a/src/acars_router_servers/udp/inputs/udp_listener_server.rs
+++ b/src/acars_router_servers/udp/inputs/udp_listener_server.rs
@@ -8,7 +8,6 @@
 // Server used to receive UDP data
 
 use crate::packet_handler::PacketHandler;
-use log::{error, info, trace, warn};
 use std::io;
 use std::net::SocketAddr;
 use std::str;
@@ -25,7 +24,7 @@ pub struct UDPListenerServer {
 impl UDPListenerServer {
     pub async fn run(
         self,
-        listen_udp_port: String,
+        listen_udp_port: &str,
         channel: Sender<serde_json::Value>,
     ) -> Result<(), io::Error> {
         let UDPListenerServer {
@@ -35,7 +34,7 @@ impl UDPListenerServer {
             reassembly_window,
         } = self;
 
-        let s = UdpSocket::bind(&listen_udp_port).await;
+        let s = UdpSocket::bind(listen_udp_port).await;
 
         match s {
             Ok(socket) => {

--- a/src/acars_router_servers/udp/outputs/udp_sender_server.rs
+++ b/src/acars_router_servers/udp/outputs/udp_sender_server.rs
@@ -7,7 +7,6 @@
 
 // Used to send UDP data
 
-use log::{debug, trace, warn};
 use serde_json::Value;
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc::Receiver;
@@ -29,60 +28,64 @@ impl UDPSenderServer {
         // We will send out a configured max amount bytes at a time until the buffer is exhausted
 
         while let Some(message) = self.channel.recv().await {
-            let message_out = message["out_json"].clone();
-            let message_as_string = format!("{}\n", message_out);
-            let message_as_bytes = message_as_string.as_bytes();
-            let message_size = message_as_bytes.len();
+            let message_as_string: Result<String, serde_json::Error> = serde_json::to_string(&message["out_json"]);
+            match message_as_string {
+                Err(parse_error) => error!("Failed to parse Value to String: {}", parse_error),
+                Ok(string) => {
+                    let message_as_bytes = string.as_bytes();
+                    let message_size: usize = message_as_bytes.len();
 
-            for addr in &self.host {
-                let mut keep_sending = true;
-                let mut buffer_position = 0;
-                let mut buffer_end = match message_as_bytes.len() < self.max_udp_packet_size {
-                    true => message_as_bytes.len(),
-                    false => self.max_udp_packet_size,
-                };
+                    for addr in &self.host {
+                        let mut keep_sending: bool = true;
+                        let mut buffer_position: usize = 0;
+                        let mut buffer_end: usize = match message_as_bytes.len() < self.max_udp_packet_size {
+                            true => message_as_bytes.len(),
+                            false => self.max_udp_packet_size,
+                        };
 
-                while keep_sending {
-                    trace!("[UDP SENDER {}] Sending {buffer_position} to {buffer_end} of {message_size} to {addr}", self.proto_name);
-                    let bytes_sent = self
-                        .socket
-                        .send_to(&message_as_bytes[buffer_position..buffer_end], addr)
-                        .await;
+                        while keep_sending {
+                            trace!("[UDP SENDER {}] Sending {buffer_position} to {buffer_end} of {message_size} to {addr}", self.proto_name);
+                            let bytes_sent = self
+                                .socket
+                                .send_to(&message_as_bytes[buffer_position..buffer_end], addr)
+                                .await;
 
-                    match bytes_sent {
-                        Ok(bytes_sent) => {
-                            debug!(
+                            match bytes_sent {
+                                Ok(bytes_sent) => {
+                                    debug!(
                                 "[UDP SENDER {}] sent {} bytes to {}",
                                 self.proto_name, bytes_sent, addr
                             );
-                        }
-                        Err(e) => {
-                            warn!(
+                                }
+                                Err(e) => {
+                                    warn!(
                                 "[UDP SENDER {}] failed to send message to {}: {:?}",
                                 self.proto_name, addr, e
                             );
-                        }
-                    }
+                                }
+                            }
 
-                    if buffer_end == message_size {
-                        keep_sending = false;
-                    } else {
-                        buffer_position = buffer_end;
-                        buffer_end = match buffer_position + self.max_udp_packet_size < message_size
-                        {
-                            true => buffer_position + self.max_udp_packet_size,
-                            false => message_size,
-                        };
+                            if buffer_end == message_size {
+                                keep_sending = false;
+                            } else {
+                                buffer_position = buffer_end;
+                                buffer_end = match buffer_position + self.max_udp_packet_size < message_size
+                                {
+                                    true => buffer_position + self.max_udp_packet_size,
+                                    false => message_size,
+                                };
 
-                        // Slow the sender down!
-                        sleep(Duration::from_millis(100)).await;
-                    }
-                    trace!(
+                                // Slow the sender down!
+                                sleep(Duration::from_millis(100)).await;
+                            }
+                            trace!(
                         "[UDP SENDER {}] New buffer start: {}, end: {}",
                         self.proto_name,
                         buffer_position,
                         buffer_end
                     );
+                        }
+                    }
                 }
             }
         }

--- a/src/config_options.rs
+++ b/src/config_options.rs
@@ -6,7 +6,6 @@
 //
 
 use clap::Parser;
-use derive_getters::Getters;
 use log::LevelFilter;
 
 #[derive(Parser, Debug, Clone)]
@@ -47,61 +46,61 @@ pub struct Input {
 
     // ACARS
     /// Comma separated list of arguments. ie 5550,5551,5552
-    #[clap(long, env = "AR_LISTEN_UDP_ACARS", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_LISTEN_UDP_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) listen_udp_acars: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5550,5551,5552
-    #[clap(long, env = "AR_LISTEN_TCP_ACARS", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_LISTEN_TCP_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) listen_tcp_acars: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5550,5551,5552
-    #[clap(long, env = "AR_RECV_TCP_ACARS", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_RECV_TCP_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) receive_tcp_acars: Option<Vec<String>>,
     /// Comma separated list of arguments. io host:5550,host:5551,host:5552
-    #[clap(long, env = "AR_RECV_ZMQ_ACARS", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_RECV_ZMQ_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) receive_zmq_acars: Option<Vec<String>>,
 
     // VDLM2
     /// Comma separated list of arguments. ie 5555;5556;5557
-    #[clap(long, env = "AR_LISTEN_UDP_VDLM2", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_LISTEN_UDP_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) listen_udp_vdlm2: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5555;5556;5557
-    #[clap(long, env = "AR_LISTEN_TCP_VDLM2", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_LISTEN_TCP_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) listen_tcp_vdlm2: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5555;5556;1557
-    #[clap(long, env = "AR_RECV_TCP_VDLM2", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_RECV_TCP_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) receive_tcp_vdlm2: Option<Vec<String>>,
     /// Comma separated list of arguments. ie  host:5550,host:5551,host:5552
-    #[clap(long, env = "AR_RECV_ZMQ_VDLM2", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_RECV_ZMQ_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) receive_zmq_vdlm2: Option<Vec<String>>,
     // JSON Output options
     // ACARS
     /// Comma separated list of arguments. ie host:5550,host:5551,host:5552
-    #[clap(long, env = "AR_SEND_UDP_ACARS", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_SEND_UDP_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) send_udp_acars: Option<Vec<String>>,
     /// Comma separated list of arguments. ie host:5550,host:5551,host:5552
-    #[clap(long, env = "AR_SEND_TCP_ACARS", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_SEND_TCP_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) send_tcp_acars: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5550,5551,5552
-    #[clap(long, env = "AR_SERVE_TCP_ACARS", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_SERVE_TCP_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) serve_tcp_acars: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5550,5551,5552
-    #[clap(long, env = "AR_SERVE_ZMQ_ACARS", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_SERVE_ZMQ_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) serve_zmq_acars: Option<Vec<String>>,
     // VDLM
     /// Comma separated list of arguments. ie host:5555,host:5556,host:5557
-    #[clap(long, env = "AR_SEND_UDP_VDLM2", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_SEND_UDP_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) send_udp_vdlm2: Option<Vec<String>>,
     /// Comma separated list of arguments. ie host:5555,host:5556,host:5557
-    #[clap(long, env = "AR_SEND_TCP_VDLM2", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_SEND_TCP_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) send_tcp_vdlm2: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5550,5551,5552
-    #[clap(long, env = "AR_SERVE_TCP_VDLM2", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_SERVE_TCP_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) serve_tcp_vdlm2: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5550,5551,5552
-    #[clap(long, env = "AR_SERVE_ZMQ_VDLM2", value_parser, value_delimiter = ',')]
+    #[clap(long, env = "AR_SERVE_ZMQ_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) serve_zmq_vdlm2: Option<Vec<String>>,
 }
 
-#[derive(Debug, Clone, Getters)]
+#[derive(Debug, Clone)]
 pub struct ACARSRouterSettings {
     pub log_level: LevelFilter,
     // This field is named opposite to the command line flag.

--- a/src/config_options.rs
+++ b/src/config_options.rs
@@ -45,57 +45,57 @@ pub struct Input {
     // Input Options
 
     // ACARS
-    /// Comma separated list of arguments. ie 5550,5551,5552
+    /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_LISTEN_UDP_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) listen_udp_acars: Option<Vec<String>>,
-    /// Comma separated list of arguments. ie 5550,5551,5552
+    /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_LISTEN_TCP_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) listen_tcp_acars: Option<Vec<String>>,
-    /// Comma separated list of arguments. ie 5550,5551,5552
+    /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_RECV_TCP_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) receive_tcp_acars: Option<Vec<String>>,
-    /// Comma separated list of arguments. io host:5550,host:5551,host:5552
+    /// Semi-Colon separated list of arguments. io host:5550;host:5551;host:5552
     #[clap(long, env = "AR_RECV_ZMQ_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) receive_zmq_acars: Option<Vec<String>>,
 
     // VDLM2
-    /// Comma separated list of arguments. ie 5555;5556;5557
+    /// Semi-Colon separated list of arguments. ie 5555;5556;5557
     #[clap(long, env = "AR_LISTEN_UDP_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) listen_udp_vdlm2: Option<Vec<String>>,
-    /// Comma separated list of arguments. ie 5555;5556;5557
+    /// Semi-Colon separated list of arguments. ie 5555;5556;5557
     #[clap(long, env = "AR_LISTEN_TCP_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) listen_tcp_vdlm2: Option<Vec<String>>,
-    /// Comma separated list of arguments. ie 5555;5556;1557
+    /// Semi-Colon separated list of arguments. ie 5555;5556;1557
     #[clap(long, env = "AR_RECV_TCP_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) receive_tcp_vdlm2: Option<Vec<String>>,
-    /// Comma separated list of arguments. ie  host:5550,host:5551,host:5552
+    /// Semi-Colon separated list of arguments. ie  host:5550;host:5551;host:5552
     #[clap(long, env = "AR_RECV_ZMQ_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) receive_zmq_vdlm2: Option<Vec<String>>,
     // JSON Output options
     // ACARS
-    /// Comma separated list of arguments. ie host:5550,host:5551,host:5552
+    /// Semi-Colon separated list of arguments. ie host:5550;host:5551;host:5552
     #[clap(long, env = "AR_SEND_UDP_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) send_udp_acars: Option<Vec<String>>,
-    /// Comma separated list of arguments. ie host:5550,host:5551,host:5552
+    /// Semi-Colon separated list of arguments. ie host:5550;host:5551;host:5552
     #[clap(long, env = "AR_SEND_TCP_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) send_tcp_acars: Option<Vec<String>>,
-    /// Comma separated list of arguments. ie 5550,5551,5552
+    /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_SERVE_TCP_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) serve_tcp_acars: Option<Vec<String>>,
-    /// Comma separated list of arguments. ie 5550,5551,5552
+    /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_SERVE_ZMQ_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) serve_zmq_acars: Option<Vec<String>>,
     // VDLM
-    /// Comma separated list of arguments. ie host:5555,host:5556,host:5557
+    /// Semi-Colon separated list of arguments. ie host:5555;host:5556;host:5557
     #[clap(long, env = "AR_SEND_UDP_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) send_udp_vdlm2: Option<Vec<String>>,
-    /// Comma separated list of arguments. ie host:5555,host:5556,host:5557
+    /// Semi-Colon separated list of arguments. ie host:5555;host:5556;host:5557
     #[clap(long, env = "AR_SEND_TCP_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) send_tcp_vdlm2: Option<Vec<String>>,
-    /// Comma separated list of arguments. ie 5550,5551,5552
+    /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_SERVE_TCP_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) serve_tcp_vdlm2: Option<Vec<String>>,
-    /// Comma separated list of arguments. ie 5550,5551,5552
+    /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_SERVE_ZMQ_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) serve_zmq_vdlm2: Option<Vec<String>>,
 }

--- a/src/config_options.rs
+++ b/src/config_options.rs
@@ -195,11 +195,9 @@ pub trait SetupLogging {
 impl SetupLogging for u8 {
     fn set_logging_level(self) -> LevelFilter {
         match self {
-            0 => LevelFilter::Error,
-            1 => LevelFilter::Warn,
-            2 => LevelFilter::Info,
-            3 => LevelFilter::Debug,
-            4..=u8::MAX => LevelFilter::Trace
+            0 => LevelFilter::Info,
+            1 => LevelFilter::Debug,
+            2..=u8::MAX => LevelFilter::Trace
         }
     }
 }

--- a/src/config_options.rs
+++ b/src/config_options.rs
@@ -17,87 +17,87 @@ pub struct Input {
     #[clap(short, long, action = clap::ArgAction::Count)]
     pub(crate) verbose: u8,
     /// Enable message deduplication
-    #[clap(long, env = "AR_ENABLE_DEDUPE")]
+    #[clap(long, env = "AR_ENABLE_DEDUPE", value_parser)]
     pub(crate) enable_dedupe: bool,
     /// Set the number of seconds that a message will be considered as a duplicate
     /// if it is received again.
-    #[clap(long, env = "AR_DEDUPE_WINDOW", default_value = "2")]
+    #[clap(long, env = "AR_DEDUPE_WINDOW", value_parser, default_value = "2")]
     pub(crate) dedupe_window: u64,
     /// Reject messages with a timestamp greater than +/- this many seconds.
-    #[clap(long, env = "AR_SKEW_WINDOW", default_value = "1")]
+    #[clap(long, env = "AR_SKEW_WINDOW", value_parser, default_value = "1")]
     pub(crate) skew_window: u64,
     /// Set maximum UDP packet size, peer-to-peer.
-    #[clap(long, env = "AR_MAX_UDP_PACKET_SIZE", default_value = "60000")]
+    #[clap(long, env = "AR_MAX_UDP_PACKET_SIZE", value_parser, default_value = "60000")]
     pub(crate) max_udp_packet_size: u64,
     // Message Modification
     /// Set to true to enable message modification
     /// This will add a "proxied" field to the message
-    #[clap(long, env = "AR_ADD_PROXY_ID")]
+    #[clap(long, env = "AR_ADD_PROXY_ID", value_parser)]
     pub(crate) add_proxy_id: bool,
     /// Override the station name in the message.
-    #[clap(long, env = "AR_OVERRIDE_STATION_NAME")]
+    #[clap(long, env = "AR_OVERRIDE_STATION_NAME", value_parser)]
     pub(crate) override_station_name: Option<String>,
     /// Print statistics every N minutes
-    #[clap(long, env = "AR_STATS_EVERY", default_value = "5")]
+    #[clap(long, env = "AR_STATS_EVERY", value_parser, default_value = "5")]
     pub(crate) stats_every: u64,
     /// Attempt message reassembly on incomplete messages within the specified number of seconds
-    #[clap(long, env = "AR_REASSEMBLY_WINDOW", default_value = "1")]
+    #[clap(long, env = "AR_REASSEMBLY_WINDOW", value_parser, default_value = "1")]
     pub(crate) reassembly_window: u64,
     // Input Options
 
     // ACARS
     /// Comma separated list of arguments. ie 5550,5551,5552
-    #[clap(long, env = "AR_LISTEN_UDP_ACARS")]
+    #[clap(long, env = "AR_LISTEN_UDP_ACARS", value_parser, value_delimiter = ',')]
     pub(crate) listen_udp_acars: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5550,5551,5552
-    #[clap(long, env = "AR_LISTEN_TCP_ACARS")]
+    #[clap(long, env = "AR_LISTEN_TCP_ACARS", value_parser, value_delimiter = ',')]
     pub(crate) listen_tcp_acars: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5550,5551,5552
-    #[clap(long, env = "AR_RECV_TCP_ACARS")]
+    #[clap(long, env = "AR_RECV_TCP_ACARS", value_parser, value_delimiter = ',')]
     pub(crate) receive_tcp_acars: Option<Vec<String>>,
     /// Comma separated list of arguments. io host:5550,host:5551,host:5552
-    #[clap(long, env = "AR_RECV_ZMQ_ACARS")]
+    #[clap(long, env = "AR_RECV_ZMQ_ACARS", value_parser, value_delimiter = ',')]
     pub(crate) receive_zmq_acars: Option<Vec<String>>,
 
     // VDLM2
     /// Comma separated list of arguments. ie 5555;5556;5557
-    #[clap(long, env = "AR_LISTEN_UDP_VDLM2")]
+    #[clap(long, env = "AR_LISTEN_UDP_VDLM2", value_parser, value_delimiter = ',')]
     pub(crate) listen_udp_vdlm2: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5555;5556;5557
-    #[clap(long, env = "AR_LISTEN_TCP_VDLM2")]
+    #[clap(long, env = "AR_LISTEN_TCP_VDLM2", value_parser, value_delimiter = ',')]
     pub(crate) listen_tcp_vdlm2: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5555;5556;1557
-    #[clap(long, env = "AR_RECV_TCP_VDLM2")]
+    #[clap(long, env = "AR_RECV_TCP_VDLM2", value_parser, value_delimiter = ',')]
     pub(crate) receive_tcp_vdlm2: Option<Vec<String>>,
     /// Comma separated list of arguments. ie  host:5550,host:5551,host:5552
-    #[clap(long, env = "AR_RECV_ZMQ_VDLM2")]
+    #[clap(long, env = "AR_RECV_ZMQ_VDLM2", value_parser, value_delimiter = ',')]
     pub(crate) receive_zmq_vdlm2: Option<Vec<String>>,
     // JSON Output options
     // ACARS
     /// Comma separated list of arguments. ie host:5550,host:5551,host:5552
-    #[clap(long, env = "AR_SEND_UDP_ACARS")]
+    #[clap(long, env = "AR_SEND_UDP_ACARS", value_parser, value_delimiter = ',')]
     pub(crate) send_udp_acars: Option<Vec<String>>,
     /// Comma separated list of arguments. ie host:5550,host:5551,host:5552
-    #[clap(long, env = "AR_SEND_TCP_ACARS")]
+    #[clap(long, env = "AR_SEND_TCP_ACARS", value_parser, value_delimiter = ',')]
     pub(crate) send_tcp_acars: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5550,5551,5552
-    #[clap(long, env = "AR_SERVE_TCP_ACARS")]
+    #[clap(long, env = "AR_SERVE_TCP_ACARS", value_parser, value_delimiter = ',')]
     pub(crate) serve_tcp_acars: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5550,5551,5552
-    #[clap(long, env = "AR_SERVE_ZMQ_ACARS")]
+    #[clap(long, env = "AR_SERVE_ZMQ_ACARS", value_parser, value_delimiter = ',')]
     pub(crate) serve_zmq_acars: Option<Vec<String>>,
     // VDLM
     /// Comma separated list of arguments. ie host:5555,host:5556,host:5557
-    #[clap(long, env = "AR_SEND_UDP_VDLM2")]
+    #[clap(long, env = "AR_SEND_UDP_VDLM2", value_parser, value_delimiter = ',')]
     pub(crate) send_udp_vdlm2: Option<Vec<String>>,
     /// Comma separated list of arguments. ie host:5555,host:5556,host:5557
-    #[clap(long, env = "AR_SEND_TCP_VDLM2")]
+    #[clap(long, env = "AR_SEND_TCP_VDLM2", value_parser, value_delimiter = ',')]
     pub(crate) send_tcp_vdlm2: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5550,5551,5552
-    #[clap(long, env = "AR_SERVE_TCP_VDLM2")]
+    #[clap(long, env = "AR_SERVE_TCP_VDLM2", value_parser, value_delimiter = ',')]
     pub(crate) serve_tcp_vdlm2: Option<Vec<String>>,
     /// Comma separated list of arguments. ie 5550,5551,5552
-    #[clap(long, env = "AR_SERVE_ZMQ_VDLM2")]
+    #[clap(long, env = "AR_SERVE_ZMQ_VDLM2", value_parser, value_delimiter = ',')]
     pub(crate) serve_zmq_vdlm2: Option<Vec<String>>,
 }
 

--- a/src/data_processing/hasher.rs
+++ b/src/data_processing/hasher.rs
@@ -5,7 +5,6 @@
 // Full license information available in the project LICENSE file.
 //
 
-use log::trace;
 use serde_json::Value;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -20,7 +19,7 @@ pub fn hash_message(mut message: Value) -> (u64, Value) {
     trace!("[Hasher] Message to be hashed: {}", msg);
     msg.hash(&mut hasher);
     let hashed_value = hasher.finish();
-    return (hashed_value, message);
+    (hashed_value, message)
 }
 
 fn generate_acarsdec_or_vdlm2dec_hashable_data(mut message: Value) -> Value {
@@ -97,7 +96,7 @@ fn generate_acarsdec_or_vdlm2dec_hashable_data(mut message: Value) -> Value {
 
     trace!("[Hasher] Hashable data: {}", message);
 
-    return message;
+    message
 }
 
 fn generate_dumpvdl2_hashable_data(mut message: Value) -> Value {
@@ -201,5 +200,5 @@ fn generate_dumpvdl2_hashable_data(mut message: Value) -> Value {
         false => (),
     }
 
-    return message;
+    message
 }

--- a/src/data_processing/message_handler.rs
+++ b/src/data_processing/message_handler.rs
@@ -14,8 +14,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
+use crate::Input;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MessageHandlerConfig {
     pub add_proxy_id: bool,
     pub dedupe: bool,
@@ -25,6 +26,34 @@ pub struct MessageHandlerConfig {
     pub should_override_station_name: bool,
     pub station_name: String,
     pub stats_every: u64,
+}
+
+impl MessageHandlerConfig {
+    pub fn new(args: &Input, queue_type: &str) -> Self {
+        if let Some(station_name) = &args.override_station_name {
+            Self {
+                add_proxy_id: args.add_proxy_id,
+                dedupe: args.enable_dedupe,
+                dedupe_window: args.dedupe_window,
+                skew_window: args.skew_window,
+                queue_type: queue_type.to_string(),
+                should_override_station_name: args.override_station_name.is_some(),
+                station_name: station_name.to_string(),
+                stats_every: args.stats_every
+            }
+        } else {
+            Self {
+                add_proxy_id: args.add_proxy_id,
+                dedupe: args.enable_dedupe,
+                dedupe_window: args.dedupe_window,
+                skew_window: args.skew_window,
+                queue_type: queue_type.to_string(),
+                should_override_station_name: false,
+                station_name: Default::default(),
+                stats_every: args.stats_every
+            }
+        }
+    }
 }
 
 pub async fn print_stats(
@@ -90,7 +119,7 @@ pub async fn clean_up_dedupe_queue(
 pub async fn watch_received_message_queue(
     mut input_queue: Receiver<serde_json::Value>,
     output_queue: Sender<serde_json::Value>,
-    config: &MessageHandlerConfig,
+    config: MessageHandlerConfig,
 ) {
     let dedupe_queue: Arc<Mutex<VecDeque<(u64, u64)>>> =
         Arc::new(Mutex::new(VecDeque::with_capacity(100)));

--- a/src/data_processing/packet_handler.rs
+++ b/src/data_processing/packet_handler.rs
@@ -5,7 +5,6 @@
 // Full license information available in the project LICENSE file.
 //
 
-use log::{debug, error, info};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -25,7 +24,7 @@ impl PacketHandler {
         PacketHandler {
             name: name.to_string(),
             queue: Arc::new(Mutex::new(HashMap::new())),
-            reassembly_window: reassembly_window,
+            reassembly_window,
         }
     }
 
@@ -39,7 +38,7 @@ impl PacketHandler {
         self.clean_queue().await;
         // FIXME: Ideally this entire function should not lock the mutex all the time
 
-        match serde_json::from_str::<serde_json::Value>(new_message_string.as_str()) {
+        match serde_json::from_str(&new_message_string) {
             Ok(msg) => {
                 self.queue.lock().await.remove(&peer);
                 return Some(msg);
@@ -48,7 +47,7 @@ impl PacketHandler {
         }
 
         let mut output_message: Option<serde_json::Value> = None;
-        let mut message_for_peer = "".to_string();
+        let mut message_for_peer = String::new();
         let mut old_time: Option<u64> = None; // Save the time of the first message for this peer
 
         // TODO: Handle message reassembly for out of sequence messages
@@ -89,7 +88,7 @@ impl PacketHandler {
             None => {
                 // If the len is 0 then it's the first non-reassembled message, so we'll save the new message in to the queue
                 // Otherwise message_for_peer should already have the old messages + the new one already in it.
-                if message_for_peer.len() == 0 {
+                if message_for_peer.is_empty() {
                     message_for_peer = new_message_string;
                 }
 

--- a/src/data_processing/packet_handler.rs
+++ b/src/data_processing/packet_handler.rs
@@ -38,12 +38,9 @@ impl PacketHandler {
         self.clean_queue().await;
         // FIXME: Ideally this entire function should not lock the mutex all the time
 
-        match serde_json::from_str(&new_message_string) {
-            Ok(msg) => {
-                self.queue.lock().await.remove(&peer);
-                return Some(msg);
-            }
-            Err(_) => (),
+        if let Ok(msg) = serde_json::from_str(&new_message_string) {
+            self.queue.lock().await.remove(&peer);
+            return Some(msg);
         }
 
         let mut output_message: Option<serde_json::Value> = None;

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -4,7 +4,6 @@
 // Permission is granted to use, copy, modify, and redistribute the work.
 // Full license information available in the project LICENSE file.
 //
-use derive_getters::Getters;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -32,7 +31,7 @@ pub struct Shared {
     pub peers: HashMap<SocketAddr, Tx>,
 }
 
-#[derive(Debug, Clone, Getters)]
+#[derive(Debug, Clone)]
 pub struct SenderServerConfig {
     pub send_udp: Option<Vec<String>>,
     pub send_tcp: Option<Vec<String>>,
@@ -57,7 +56,7 @@ impl SenderServerConfig {
     }
 }
 
-#[derive(Debug, Clone, Default, Getters)]
+#[derive(Debug, Clone, Default)]
 pub struct OutputServerConfig {
     pub listen_udp: Option<Vec<String>>,
     pub listen_tcp: Option<Vec<String>>,

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -32,22 +32,54 @@ pub struct Shared {
     pub peers: HashMap<SocketAddr, Tx>,
 }
 
-#[derive(Getters, Clone)]
+#[derive(Debug, Clone, Getters)]
 pub struct SenderServerConfig {
-    pub send_udp: Vec<String>,
-    pub send_tcp: Vec<String>,
-    pub serve_tcp: Vec<String>,
-    pub serve_zmq: Vec<String>,
+    pub send_udp: Option<Vec<String>>,
+    pub send_tcp: Option<Vec<String>>,
+    pub serve_tcp: Option<Vec<String>>,
+    pub serve_zmq: Option<Vec<String>>,
     pub max_udp_packet_size: usize,
 }
 
-#[derive(Getters, Clone)]
+impl SenderServerConfig {
+    pub fn new(send_udp: &Option<Vec<String>>,
+               send_tcp: &Option<Vec<String>>,
+               serve_tcp: &Option<Vec<String>>,
+               serve_zmq: &Option<Vec<String>>,
+               max_udp_packet_size: &u64) -> Self {
+        Self {
+            send_udp: send_udp.clone(),
+            send_tcp: send_tcp.clone(),
+            serve_tcp: serve_tcp.clone(),
+            serve_zmq: serve_zmq.clone(),
+            max_udp_packet_size: *max_udp_packet_size as usize
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Getters)]
 pub struct OutputServerConfig {
-    pub listen_udp: Vec<String>,
-    pub listen_tcp: Vec<String>,
-    pub receive_tcp: Vec<String>,
-    pub receive_zmq: Vec<String>,
+    pub listen_udp: Option<Vec<String>>,
+    pub listen_tcp: Option<Vec<String>>,
+    pub receive_tcp: Option<Vec<String>>,
+    pub receive_zmq: Option<Vec<String>>,
     pub reassembly_window: u64,
+}
+
+impl OutputServerConfig {
+    pub fn new(listen_udp: &Option<Vec<String>>,
+               listen_tcp: &Option<Vec<String>>,
+               receive_tcp: &Option<Vec<String>>,
+               receive_zmq: &Option<Vec<String>>,
+               reassembly_window: &u64) -> Self {
+        Self {
+            listen_udp: listen_udp.clone(),
+            listen_tcp: listen_tcp.clone(),
+            receive_tcp: receive_tcp.clone(),
+            receive_zmq: receive_zmq.clone(),
+            reassembly_window: *reassembly_window
+        }
+    }
 }
 
 // create ReconnectOptions. We want the TCP stuff that goes out and connects to clients

--- a/src/helper_functions.rs
+++ b/src/helper_functions.rs
@@ -6,7 +6,7 @@
 //
 
 pub fn should_start_service(config: &Vec<String>) -> bool {
-    config.len() > 0 && config[0].len() > 0
+    !config.is_empty() && !config[0].is_empty()
 }
 
 pub fn exit_process(code: i32) {
@@ -16,7 +16,7 @@ pub fn exit_process(code: i32) {
 pub fn strip_line_endings(line: &String) -> String {
     return line
         .strip_suffix("\r\n")
-        .or(line.strip_suffix("\n"))
-        .unwrap_or(&line)
+        .or(line.strip_suffix('\n'))
+        .unwrap_or(line)
         .to_string();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,22 @@
 // Full license information available in the project LICENSE file.
 //
 
+#[macro_use] extern crate log;
+extern crate tokio;
+extern crate tokio_stream;
+extern crate tokio_util;
+extern crate futures;
+extern crate clap;
+extern crate chrono;
+extern crate serde;
+extern crate serde_json;
+extern crate zmq;
+extern crate tmq;
+extern crate failure;
+extern crate stubborn_io;
+extern crate env_logger;
+extern crate derive_getters;
+
 #[path = "./config_options.rs"]
 mod config_options;
 #[path = "./data_processing/hasher.rs"]
@@ -50,28 +66,19 @@ mod generics;
 mod packet_handler;
 
 use chrono::Local;
-use config_options::ACARSRouterSettings;
 use env_logger::Builder;
-use generics::{OutputServerConfig, SenderServerConfig};
-use helper_functions::exit_process;
-use listener_servers::start_listener_servers;
-use log::{debug, error, info, trace};
-use message_handler::{watch_received_message_queue, MessageHandlerConfig};
-use sanity_checker::check_config_option_sanity;
-use sender_servers::start_sender_servers;
 use std::error::Error;
 use std::io::Write;
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration};
+use clap::Parser;
+use crate::config_options::{Input, SetupLogging};
+use crate::generics::{OutputServerConfig, SenderServerConfig};
+use crate::listener_servers::start_listener_servers;
+use crate::message_handler::{watch_received_message_queue, MessageHandlerConfig};
+use crate::sender_servers::start_sender_servers;
 
-async fn start_processes() {
-    let config: ACARSRouterSettings = ACARSRouterSettings::load_values();
-    let log_level = config.log_level();
-    let should_start_acars_watcher =
-        config.should_start_acars_inputs() && config.should_start_acars_outputs();
-    let should_start_vdlm_watcher =
-        config.should_start_vdlm2_inputs() && config.should_start_vdlm2_outputs();
-
+async fn start_processes(args: Input) {
     Builder::new()
         .format(|buf, record| {
             writeln!(
@@ -82,37 +89,16 @@ async fn start_processes() {
                 record.args()
             )
         })
-        .filter(None, log_level.clone())
+        .filter(None, args.verbose.set_logging_level())
         .init();
 
-    config.print_values();
+    args.print_values();
 
-    match check_config_option_sanity(&config) {
-        Ok(_) => {
-            info!("Configuration is valid. Starting ACARS Router");
-        }
-        Err(e) => {
-            error!("Configuration is invalid. Exiting ACARS Router");
-            error!("{}", e);
-            exit_process(12);
-        }
-    }
-    let message_handler_config_acars = MessageHandlerConfig {
-        add_proxy_id: config.add_proxy_id,
-        dedupe: config.dedupe,
-        dedupe_window: config.dedupe_window,
-        skew_window: config.skew_window,
-        queue_type: "ACARS".to_string(),
-        should_override_station_name: config.should_override_station_name,
-        station_name: config.override_station_name.clone(),
-        stats_every: config.stats_every,
-    };
-
-    let mut message_handler_config_vdlm = message_handler_config_acars.clone();
-    message_handler_config_vdlm.queue_type = "VDLM".to_string();
+    let message_handler_config_acars = MessageHandlerConfig::new(&args, "ACARS");
+    let message_handler_config_vdlm = MessageHandlerConfig::new(&args, "VDLM");
 
     // Print the log level out to the user
-    info!("Log level: {:?}", config.log_level());
+    // info!("Log level: {:?}", config.log_level());
 
     // ACARS Servers
     // Create the input channel all receivers will send their data to.
@@ -131,108 +117,77 @@ async fn start_processes() {
     // start the input servers
     debug!("Starting input servers");
     // start_listener_servers(&config, tx_receivers_acars, tx_receivers_vdlm);
+    info!("Starting ACARS input servers");
+    let acars_input_config = OutputServerConfig::new(&args.listen_udp_acars,
+                                                     &args.listen_tcp_acars,
+                                                     &args.receive_tcp_acars,
+                                                     &args.receive_zmq_acars,
+                                                     &args.reassembly_window);
+    tokio::spawn(async move {
+        start_listener_servers(acars_input_config, tx_receivers_acars, "ACARS");
+    });
 
-    if config.should_start_acars_inputs() {
-        // start the acars input servers
-        info!("Starting ACARS input servers");
-        let acars_input_config = OutputServerConfig {
-            listen_udp: config.listen_udp_acars().clone(),
-            listen_tcp: config.listen_tcp_acars().clone(),
-            receive_zmq: config.receive_zmq_acars().clone(),
-            receive_tcp: config.receive_tcp_acars().clone(),
-            reassembly_window: config.reassembly_window().clone(),
-        };
-
-        tokio::spawn(async move {
-            start_listener_servers(acars_input_config, tx_receivers_acars, "ACARS".to_string());
-        });
-    } else {
-        info!("No valid ACARS input servers configured. Not starting ACARS Input Servers");
-    }
-
-    if config.should_start_vdlm2_inputs() {
-        // start the vdlm input servers
-        info!("Starting VDLM2 input servers");
-        let vdlm_input_config = OutputServerConfig {
-            listen_udp: config.listen_udp_vdlm2().clone(),
-            listen_tcp: config.listen_tcp_vdlm2().clone(),
-            receive_zmq: config.receive_zmq_vdlm2().clone(),
-            receive_tcp: config.receive_tcp_vdlm2().clone(),
-            reassembly_window: config.reassembly_window().clone(),
-        };
-
-        tokio::spawn(async move {
-            start_listener_servers(vdlm_input_config, tx_receivers_vdlm, "VDLM".to_string());
-        });
-    } else {
-        info!("No valid VDLM2 input servers configured. Not starting VDLM2 Input Servers");
-    }
+    let vdlm_input_config = OutputServerConfig::new(&args.listen_udp_vdlm2,
+                                                    &args.listen_tcp_vdlm2,
+                                                    &args.receive_zmq_vdlm2,
+                                                    &args.receive_tcp_vdlm2,
+                                                    &args.reassembly_window);
+    tokio::spawn(async move {
+        start_listener_servers(vdlm_input_config, tx_receivers_vdlm, "VDLM");
+    });
 
     // start the output servers
     debug!("Starting output servers");
-    if config.should_start_acars_outputs() {
-        info!("Starting ACARS Output Servers");
-        let acars_output_config = SenderServerConfig {
-            send_udp: config.send_udp_acars().clone(),
-            send_tcp: config.send_tcp_acars().clone(),
-            serve_zmq: config.serve_zmq_acars().clone(),
-            serve_tcp: config.serve_tcp_acars().clone(),
-            max_udp_packet_size: config.max_udp_packet_size().clone(),
-        };
 
-        tokio::spawn(async move {
-            start_sender_servers(
-                &acars_output_config,
-                rx_processed_acars,
-                "ACARS".to_string(),
-            )
-            .await;
-        });
-    } else {
-        info!("No valid ACARS outputs configured. Not starting ACARS Output Servers");
-    }
+    info!("Starting ACARS Output Servers");
+    let acars_output_config: SenderServerConfig = SenderServerConfig::new(&args.send_udp_acars,
+                                                      &args.send_tcp_acars,
+                                                      &args.serve_zmq_acars,
+                                                      &args.serve_tcp_acars,
+                                                      &args.max_udp_packet_size);
 
-    if config.should_start_vdlm2_outputs() {
-        info!("Starting VDLM Output Servers");
-        let vdlm_output_config = SenderServerConfig {
-            send_udp: config.send_udp_vdlm2().clone(),
-            send_tcp: config.send_tcp_vdlm2().clone(),
-            serve_zmq: config.serve_zmq_vdlm2().clone(),
-            serve_tcp: config.serve_tcp_vdlm2().clone(),
-            max_udp_packet_size: config.max_udp_packet_size().clone(),
-        };
+    tokio::spawn(async move {
+        start_sender_servers(
+            acars_output_config,
+            rx_processed_acars,
+            "ACARS",
+        ).await;
+    });
 
-        tokio::spawn(async move {
-            start_sender_servers(&vdlm_output_config, rx_processed_vdlm, "VDLM".to_string()).await;
-        });
-    } else {
-        info!("No valid VDLM outputs configured. Not starting VDLM Output Servers");
-    }
+    info!("Starting VDLM Output Servers");
+    let vdlm_output_config = SenderServerConfig::new(&args.send_udp_vdlm2,
+                                                     &args.send_tcp_vdlm2,
+                                                     &args.serve_zmq_vdlm2,
+                                                     &args.serve_tcp_vdlm2,
+                                                     &args.max_udp_packet_size);
+
+    tokio::spawn(async move {
+        start_sender_servers(vdlm_output_config, rx_processed_vdlm, "VDLM").await;
+    });
 
     // Start the message handler tasks.
     // Don't start the queue watcher UNLESS there is a valid input source AND output source for the message type
 
     debug!("Starting the message handler tasks");
 
-    if should_start_acars_watcher {
+    if args.acars_configured() {
         tokio::spawn(async move {
             watch_received_message_queue(
                 rx_receivers_acars,
                 tx_processed_acars,
-                &message_handler_config_acars,
-            )
-            .await
+                message_handler_config_acars,
+            ).await
         });
     } else {
         info!("Not starting the ACARS message handler task. No input and/or output sources specified.");
     }
 
-    if should_start_vdlm_watcher {
+    if args.vdlm_configured() {
         tokio::spawn(async move {
             watch_received_message_queue(
                 rx_receivers_vdlm,
                 tx_processed_vdlm,
-                &message_handler_config_vdlm,
+                message_handler_config_vdlm,
             )
             .await;
         });
@@ -255,6 +210,7 @@ async fn start_processes() {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    start_processes().await;
+    let args: Input = Input::parse();
+    start_processes(args).await;
     Ok(())
 }

--- a/src/sanity_checker.rs
+++ b/src/sanity_checker.rs
@@ -20,112 +20,112 @@ pub fn check_config_option_sanity(config_options: &ACARSRouterSettings) -> Resul
     // Will always be a valid number because the Clap parser will die if the input is bad
 
     if !check_ports_are_valid(
-        config_options.listen_udp_acars(),
+        &config_options.listen_udp_acars,
         "AR_LISTEN_UDP_ACARS/--listen-udp-acars",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid(
-        config_options.listen_tcp_acars(),
+        &config_options.listen_tcp_acars,
         "AR_LISTEN_TCP_ACARS/--listen-tcp-acars",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid_with_host(
-        config_options.receive_tcp_acars(),
+        &config_options.receive_tcp_acars,
         "AR_RECEIVE_TCP_ACARS/--receive-tcp-acars",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid(
-        config_options.listen_udp_vdlm2(),
+        &config_options.listen_udp_vdlm2,
         "AR_LISTEN_UDP_VDLM2/--listen-udp-vdlm2",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid(
-        config_options.listen_tcp_vdlm2(),
+        &config_options.listen_tcp_vdlm2,
         "AR_LISTEN_TCP_VDLM2/--listen-tcp-vdlm2",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid_with_host(
-        config_options.receive_tcp_vdlm2(),
+        &config_options.receive_tcp_vdlm2,
         "AR_RECEIVE_TCP_VDLM2/--receive-tcp-vdlm2",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid_with_host(
-        config_options.send_udp_acars(),
+        &config_options.send_udp_acars,
         "AR_SEND_UDP_ACARS/--send-udp-acars",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid_with_host(
-        config_options.send_udp_vdlm2(),
+        &config_options.send_udp_vdlm2,
         "AR_SEND_UDP_VDLM2/--send-udp-vdlm2",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid_with_host(
-        config_options.send_tcp_acars(),
+        &config_options.send_tcp_acars,
         "AR_SEND_TCP_ACARS/--send-tcp-acars",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid_with_host(
-        config_options.send_tcp_vdlm2(),
+        &config_options.send_tcp_vdlm2,
         "AR_SEND_TCP_VDLM2/--send-tcp-vdlm2",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid_with_host(
-        config_options.receive_zmq_vdlm2(),
+        &config_options.receive_zmq_vdlm2,
         "AR_RECEIVE_ZMQ_VDLM2/--receive-zmq-vdlm2",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid_with_host(
-        config_options.receive_zmq_acars(),
+        &config_options.receive_zmq_acars,
         "AR_RECEIVE_ZMQ_ACARS/--receive-zmq-acars",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid(
-        config_options.serve_tcp_acars(),
+        &config_options.serve_tcp_acars,
         "AR_SERVE_TCP_ACARS/--serve-tcp-acars",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid(
-        config_options.serve_tcp_vdlm2(),
+        &config_options.serve_tcp_vdlm2,
         "AR_SERVE_TCP_VDLM2/--serve-tcp-vdlm2",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid(
-        config_options.serve_zmq_acars(),
+        &config_options.serve_zmq_acars,
         "AR_SERVE_ZMQ_ACARS/--serve-zmq-acars",
     ) {
         is_input_sane = false;
     }
 
     if !check_ports_are_valid(
-        config_options.serve_zmq_vdlm2(),
+        &config_options.serve_zmq_vdlm2,
         "AR_SERVE_ZMQ_VDLM2/--serve-zmq-vdlm2",
     ) {
         is_input_sane = false;
@@ -139,13 +139,13 @@ pub fn check_config_option_sanity(config_options: &ACARSRouterSettings) -> Resul
 
 fn check_ports_are_valid(ports: &Vec<String>, name: &str) -> bool {
     // if we have a zero length vector the input is always bad
-    if ports.len() == 0 {
+    if ports.is_empty() {
         return false;
     }
 
     // if the vector value of the first element is zero length the user
     // didn't specify the option and the input is valid
-    if ports[0].len() == 0 {
+    if ports[0].is_empty() {
         return true;
     }
 
@@ -167,15 +167,15 @@ fn check_ports_are_valid(ports: &Vec<String>, name: &str) -> bool {
         }
     }
 
-    return is_input_sane;
+    is_input_sane
 }
 
 fn check_ports_are_valid_with_host(ports: &Vec<String>, name: &str) -> bool {
-    if ports.len() == 0 {
+    if ports.is_empty() {
         return false;
     }
 
-    if ports[0].len() == 0 {
+    if ports[0].is_empty() {
         return true;
     }
 
@@ -184,7 +184,7 @@ fn check_ports_are_valid_with_host(ports: &Vec<String>, name: &str) -> bool {
     for port in ports {
         // split the host and port
 
-        let split_port: Vec<&str> = port.split(":").collect();
+        let split_port: Vec<&str> = port.split(':').collect();
 
         if split_port.len() != 2 {
             error!(
@@ -209,5 +209,5 @@ fn check_ports_are_valid_with_host(ports: &Vec<String>, name: &str) -> bool {
         }
     }
 
-    return is_input_sane;
+    is_input_sane
 }


### PR DESCRIPTION
So I started at the config loading and setting about improving the usage of clap by pulling in the `env` feature for it.

After that, it was setting about putting in `Optional<>` in a number of the items that you were setting as empty strings for your defaults.

Next step was to make clap built the `Vec<String>` from the initial loading, instead of having to pass in each item, split on your chosen separator and build back out.

This means that anything that is desired as an optional parameter (be it env provided or switch provided is now built as an `Option<Vec<String>>` and should be pulled in at runtime without needing to be processed after the fact.

After that, it was adapting some of your existing functions to take in this, and move some of the start-up logic to the processing itself.

There are some items that I have not removed as yet because I'm unsure if they're items that you really do need still as they all appear related to bringing in the environment variables.

I think there's going to be improvements that can be made to the various message handlers, but a few of those things will really depend on whether there are set formats for messages that can be built as structs and serialised/deserialised accordingly. Anything that uses the `serde_json::Value` type has a large overhead of extra CPU time (and to a point memory as well).