### PR TITLE
Update port options to u16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "acars_router"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acars_router"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Fred Clausen", "Mike Nye"]
 description = "ACARS Router: A Utility to ingest ACARS/VDLM2 from many sources, process, and feed out to many consumers."

--- a/rootfs/etc/services.d/acars_router/run
+++ b/rootfs/etc/services.d/acars_router/run
@@ -9,8 +9,6 @@ elif [[ ${AR_VERBOSITY,,} =~ trace  || $AR_VERBOSITY -ge 2 ]]; then
     DEBUG_LEVEL+=("-vv")
 fi
 
-echo "${DEBUG_LEVEL[@]}"
-
 if /opt/acars_router.amd64 --version > /dev/null 2>&1; then
     /opt/acars_router.amd64 "${DEBUG_LEVEL[@]}"
 

--- a/src/acars_router_servers/listener_servers.rs
+++ b/src/acars_router_servers/listener_servers.rs
@@ -87,7 +87,7 @@ fn start_zmq_listener_servers(decoder_type: &str, hosts: &[String], channel: Sen
 
 fn start_tcp_listener_servers(
     decoder_type: &str,
-    ports: &[String],
+    ports: &[u16],
     channel: Sender<Value>,
     reassembly_window: &u64,
 ) {
@@ -107,7 +107,7 @@ fn start_tcp_listener_servers(
 
 fn start_udp_listener_servers(
     decoder_type: &str,
-    ports: &[String],
+    ports: &[u16],
     channel: Sender<Value>,
     reassembly_window: &u64,
 ) {
@@ -130,7 +130,7 @@ fn start_udp_listener_servers(
 
 fn start_tcp_receiver_servers(
     decoder_type: &str,
-    hosts: &Vec<String>,
+    hosts: &[u16],
     channel: Sender<Value>,
     reassembly_window: &u64,
 ) {

--- a/src/acars_router_servers/listener_servers.rs
+++ b/src/acars_router_servers/listener_servers.rs
@@ -130,7 +130,7 @@ fn start_udp_listener_servers(
 
 fn start_tcp_receiver_servers(
     decoder_type: &str,
-    hosts: &[u16],
+    hosts: &[String],
     channel: Sender<Value>,
     reassembly_window: &u64,
 ) {

--- a/src/config_options.rs
+++ b/src/config_options.rs
@@ -52,13 +52,13 @@ pub struct Input {
     // ACARS
     /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_LISTEN_UDP_ACARS", value_parser, value_delimiter = ';')]
-    pub(crate) listen_udp_acars: Option<Vec<String>>,
+    pub(crate) listen_udp_acars: Option<Vec<u16>>,
     /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_LISTEN_TCP_ACARS", value_parser, value_delimiter = ';')]
-    pub(crate) listen_tcp_acars: Option<Vec<String>>,
+    pub(crate) listen_tcp_acars: Option<Vec<u16>>,
     /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_RECV_TCP_ACARS", value_parser, value_delimiter = ';')]
-    pub(crate) receive_tcp_acars: Option<Vec<String>>,
+    pub(crate) receive_tcp_acars: Option<Vec<u16>>,
     /// Semi-Colon separated list of arguments. io host:5550;host:5551;host:5552
     #[clap(long, env = "AR_RECV_ZMQ_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) receive_zmq_acars: Option<Vec<String>>,
@@ -66,13 +66,13 @@ pub struct Input {
     // VDLM2
     /// Semi-Colon separated list of arguments. ie 5555;5556;5557
     #[clap(long, env = "AR_LISTEN_UDP_VDLM2", value_parser, value_delimiter = ';')]
-    pub(crate) listen_udp_vdlm2: Option<Vec<String>>,
+    pub(crate) listen_udp_vdlm2: Option<Vec<u16>>,
     /// Semi-Colon separated list of arguments. ie 5555;5556;5557
     #[clap(long, env = "AR_LISTEN_TCP_VDLM2", value_parser, value_delimiter = ';')]
-    pub(crate) listen_tcp_vdlm2: Option<Vec<String>>,
+    pub(crate) listen_tcp_vdlm2: Option<Vec<u16>>,
     /// Semi-Colon separated list of arguments. ie 5555;5556;1557
     #[clap(long, env = "AR_RECV_TCP_VDLM2", value_parser, value_delimiter = ';')]
-    pub(crate) receive_tcp_vdlm2: Option<Vec<String>>,
+    pub(crate) receive_tcp_vdlm2: Option<Vec<u16>>,
     /// Semi-Colon separated list of arguments. ie  host:5550;host:5551;host:5552
     #[clap(long, env = "AR_RECV_ZMQ_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) receive_zmq_vdlm2: Option<Vec<String>>,
@@ -86,10 +86,10 @@ pub struct Input {
     pub(crate) send_tcp_acars: Option<Vec<String>>,
     /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_SERVE_TCP_ACARS", value_parser, value_delimiter = ';')]
-    pub(crate) serve_tcp_acars: Option<Vec<String>>,
+    pub(crate) serve_tcp_acars: Option<Vec<u16>>,
     /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_SERVE_ZMQ_ACARS", value_parser, value_delimiter = ';')]
-    pub(crate) serve_zmq_acars: Option<Vec<String>>,
+    pub(crate) serve_zmq_acars: Option<Vec<u16>>,
     // VDLM
     /// Semi-Colon separated list of arguments. ie host:5555;host:5556;host:5557
     #[clap(long, env = "AR_SEND_UDP_VDLM2", value_parser, value_delimiter = ';')]
@@ -99,10 +99,10 @@ pub struct Input {
     pub(crate) send_tcp_vdlm2: Option<Vec<String>>,
     /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_SERVE_TCP_VDLM2", value_parser, value_delimiter = ';')]
-    pub(crate) serve_tcp_vdlm2: Option<Vec<String>>,
+    pub(crate) serve_tcp_vdlm2: Option<Vec<u16>>,
     /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_SERVE_ZMQ_VDLM2", value_parser, value_delimiter = ';')]
-    pub(crate) serve_zmq_vdlm2: Option<Vec<String>>,
+    pub(crate) serve_zmq_vdlm2: Option<Vec<u16>>,
 }
 
 impl Input {

--- a/src/config_options.rs
+++ b/src/config_options.rs
@@ -56,9 +56,9 @@ pub struct Input {
     /// Semi-Colon separated list of arguments. ie 5550;5551;5552
     #[clap(long, env = "AR_LISTEN_TCP_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) listen_tcp_acars: Option<Vec<u16>>,
-    /// Semi-Colon separated list of arguments. ie 5550;5551;5552
+    /// Semi-Colon separated list of arguments. ie host:5550;host:5551;host:5552
     #[clap(long, env = "AR_RECV_TCP_ACARS", value_parser, value_delimiter = ';')]
-    pub(crate) receive_tcp_acars: Option<Vec<u16>>,
+    pub(crate) receive_tcp_acars: Option<Vec<String>>,
     /// Semi-Colon separated list of arguments. io host:5550;host:5551;host:5552
     #[clap(long, env = "AR_RECV_ZMQ_ACARS", value_parser, value_delimiter = ';')]
     pub(crate) receive_zmq_acars: Option<Vec<String>>,
@@ -70,9 +70,9 @@ pub struct Input {
     /// Semi-Colon separated list of arguments. ie 5555;5556;5557
     #[clap(long, env = "AR_LISTEN_TCP_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) listen_tcp_vdlm2: Option<Vec<u16>>,
-    /// Semi-Colon separated list of arguments. ie 5555;5556;1557
+    /// Semi-Colon separated list of arguments. ie host:5550;host:5551;host:5552
     #[clap(long, env = "AR_RECV_TCP_VDLM2", value_parser, value_delimiter = ';')]
-    pub(crate) receive_tcp_vdlm2: Option<Vec<u16>>,
+    pub(crate) receive_tcp_vdlm2: Option<Vec<String>>,
     /// Semi-Colon separated list of arguments. ie  host:5550;host:5551;host:5552
     #[clap(long, env = "AR_RECV_ZMQ_VDLM2", value_parser, value_delimiter = ';')]
     pub(crate) receive_zmq_vdlm2: Option<Vec<String>>,

--- a/src/config_options.rs
+++ b/src/config_options.rs
@@ -171,3 +171,24 @@ impl SetupLogging for u8 {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_set_logging_level() {
+        let info_level: u8 = 0;
+        let debug_level: u8 = 1;
+        let trace_level: u8 = 2;
+        let stupid_levels: u8 = 255;
+        let info_level_logging: LevelFilter = info_level.set_logging_level();
+        let debug_level_logging: LevelFilter = debug_level.set_logging_level();
+        let trace_level_logging: LevelFilter = trace_level.set_logging_level();
+        let stupid_levels_logging: LevelFilter = stupid_levels.set_logging_level();
+        assert_eq!(info_level_logging, LevelFilter::Info);
+        assert_eq!(debug_level_logging, LevelFilter::Debug);
+        assert_eq!(trace_level_logging, LevelFilter::Trace);
+        assert_eq!(stupid_levels_logging, LevelFilter::Trace);
+    }
+}

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -61,7 +61,7 @@ impl SenderServerConfig {
 pub struct OutputServerConfig {
     pub listen_udp: Option<Vec<u16>>,
     pub listen_tcp: Option<Vec<u16>>,
-    pub receive_tcp: Option<Vec<u16>>,
+    pub receive_tcp: Option<Vec<String>>,
     pub receive_zmq: Option<Vec<String>>,
     pub reassembly_window: u64,
 }
@@ -70,7 +70,7 @@ impl OutputServerConfig {
     pub fn new(
         listen_udp: &Option<Vec<u16>>,
         listen_tcp: &Option<Vec<u16>>,
-        receive_tcp: &Option<Vec<u16>>,
+        receive_tcp: &Option<Vec<String>>,
         receive_zmq: &Option<Vec<String>>,
         reassembly_window: &u64,
     ) -> Self {

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -34,8 +34,8 @@ pub struct Shared {
 pub struct SenderServerConfig {
     pub send_udp: Option<Vec<String>>,
     pub send_tcp: Option<Vec<String>>,
-    pub serve_tcp: Option<Vec<String>>,
-    pub serve_zmq: Option<Vec<String>>,
+    pub serve_tcp: Option<Vec<u16>>,
+    pub serve_zmq: Option<Vec<u16>>,
     pub max_udp_packet_size: usize,
 }
 
@@ -43,8 +43,8 @@ impl SenderServerConfig {
     pub fn new(
         send_udp: &Option<Vec<String>>,
         send_tcp: &Option<Vec<String>>,
-        serve_tcp: &Option<Vec<String>>,
-        serve_zmq: &Option<Vec<String>>,
+        serve_tcp: &Option<Vec<u16>>,
+        serve_zmq: &Option<Vec<u16>>,
         max_udp_packet_size: &u64,
     ) -> Self {
         Self {
@@ -59,18 +59,18 @@ impl SenderServerConfig {
 
 #[derive(Debug, Clone, Default)]
 pub struct OutputServerConfig {
-    pub listen_udp: Option<Vec<String>>,
-    pub listen_tcp: Option<Vec<String>>,
-    pub receive_tcp: Option<Vec<String>>,
+    pub listen_udp: Option<Vec<u16>>,
+    pub listen_tcp: Option<Vec<u16>>,
+    pub receive_tcp: Option<Vec<u16>>,
     pub receive_zmq: Option<Vec<String>>,
     pub reassembly_window: u64,
 }
 
 impl OutputServerConfig {
     pub fn new(
-        listen_udp: &Option<Vec<String>>,
-        listen_tcp: &Option<Vec<String>>,
-        receive_tcp: &Option<Vec<String>>,
+        listen_udp: &Option<Vec<u16>>,
+        listen_tcp: &Option<Vec<u16>>,
+        receive_tcp: &Option<Vec<u16>>,
         receive_zmq: &Option<Vec<String>>,
         reassembly_window: &u64,
     ) -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,10 +212,6 @@ async fn start_processes(args: Input) {
         );
     }
 
-    // TODO: Is this the best way of doing this?
-    // Without sleeping and waiting the entire program exits immediately.
-    // For reasons
-
     trace!("Starting the sleep loop");
 
     loop {

--- a/src/sanity_checker.rs
+++ b/src/sanity_checker.rs
@@ -171,7 +171,14 @@ fn check_ports_are_valid_with_host(socket_addresses: &Option<Vec<String>>, name:
                     error!("{}: Failed to validate that {} is a properly formatted socket: {}", name, socket, parse_error);
                     is_input_sane = false;
                 },
-                Ok(_) => trace!("{} is a valid socket address", socket)
+                Ok(parsed_socket) => {
+                    if parsed_socket.port().eq(&0) {
+                        error!("{}: Socket address is valid, but the port provided is zero!", name);
+                        is_input_sane = false;
+                    } else {
+                        trace!("{} is a valid socket address", socket);
+                    }
+                }
             }
         }
     }

--- a/src/sanity_checker.rs
+++ b/src/sanity_checker.rs
@@ -34,7 +34,7 @@ pub fn check_config_option_sanity(config_options: &Input) -> Result<(), String> 
         is_input_sane = false;
     }
 
-    if !check_ports_are_valid(
+    if !check_ports_are_valid_with_host(
         &config_options.receive_tcp_acars,
         "AR_RECEIVE_TCP_ACARS/--receive-tcp-acars",
     ) {
@@ -55,7 +55,7 @@ pub fn check_config_option_sanity(config_options: &Input) -> Result<(), String> 
         is_input_sane = false;
     }
 
-    if !check_ports_are_valid(
+    if !check_ports_are_valid_with_host(
         &config_options.receive_tcp_vdlm2,
         "AR_RECEIVE_TCP_VDLM2/--receive-tcp-vdlm2",
     ) {


### PR DESCRIPTION
Went through and updated anything that was in the configuration examples as being purely port number based and replace it from being `Option<Vec<String>>` to `Option<Vec<u16>>`. I went with a u16 because the maximum size is 65535. Attempting to use anything larger and clap will reject it when you attempt to start the application.

Updated a few other structs that were impacted by the type change, along with functions that used them.

Updated the configuration sanity checking to handle this change, and wrote some tests to prove that it works.

Also updated the host sanity check to use `SocketAddr` to do the heavy lifting for us, along with a test to prove that the updated check works.

For the sake of it, wrote a test to confirm the right logging level is being set as well.

The tests can be run using `cargo test`.