### PR TITLE
Update some cargo manifests to support the new changes in 1.64.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "acars_config"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "acars_logging",
  "clap",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "acars_connection_manager"
-version = "0.1.2"
+version = "1.0.11"
 dependencies = [
  "acars_config",
  "acars_vdlm2_parser",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "acars_logging"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "chrono",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,15 @@ members = [
     "rust/libraries/acars_logging",
     "rust/libraries/acars_connection_manager"
 ]
+
+[workspace.package]
+edition = "2021"
+version = "1.0.11"
+authors = ["Fred Clausen", "Mike Nye", "Alex Austin"]
+description = "ACARS Router: A Utility to ingest ACARS/VDLM2 from many sources, process, and feed out to many consumers."
+documentation = "https://github.com/sdr-enthusiasts/acars_router"
+homepage = "https://github.com/sdr-enthusiasts/acars_router"
+repository = "https://github.com/sdr-enthusiasts/acars_router"
+readme = "README.md"
+license = "MIT"
+rust-version = "1.64"

--- a/rust/bin/acars_router/Cargo.toml
+++ b/rust/bin/acars_router/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "acars_router"
-version = "1.0.11"
-edition = "2021"
-authors = ["Fred Clausen", "Mike Nye", "Alex Austin"]
-description = "ACARS Router: A Utility to ingest ACARS/VDLM2 from many sources, process, and feed out to many consumers."
-documentation = "https://github.com/sdr-enthusiasts/acars_router"
-homepage = "https://github.com/sdr-enthusiasts/acars_router"
-repository = "https://github.com/sdr-enthusiasts/acars_router"
-readme = "README.md"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 log = "0.4.17"

--- a/rust/libraries/acars_config/Cargo.toml
+++ b/rust/libraries/acars_config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "acars_config"
-version = "1.0.10"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust/libraries/acars_connection_manager/Cargo.toml
+++ b/rust/libraries/acars_connection_manager/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "acars_connection_manager"
-version = "0.1.2"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust/libraries/acars_logging/Cargo.toml
+++ b/rust/libraries/acars_logging/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "acars_logging"
-version = "1.0.10"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This will make the minimum `rust-version` 1.64.0 as a result though.


This implements the changes brought in by: https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html, and specifically https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table

This is _not_ implementing workspace dependencies, that's a small corner of pain I'd like to unravel at another time.
