### PR TITLE
Bump the version for acars_router and acars_vdlm2_parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "acars_config"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "acars_logging",
  "clap",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "acars_connection_manager"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "acars_config",
  "acars_vdlm2_parser",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "acars_logging"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "chrono",
  "env_logger",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "acars_router"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "acars_config",
  "acars_connection_manager",
@@ -54,8 +54,8 @@ dependencies = [
 
 [[package]]
 name = "acars_vdlm2_parser"
-version = "0.1.7"
-source = "git+https://github.com/jcdeimos/acars_vdlm2_parser#cd1de25c51d72595eb5295af698bc2c8b97492c1"
+version = "0.1.11"
+source = "git+https://github.com/jcdeimos/acars_vdlm2_parser#28fadf1206bf8f1c9961a528b7a9d9d83e5f1e3b"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "1.0.11"
+version = "1.0.12"
 authors = ["Fred Clausen", "Mike Nye", "Alex Austin"]
 description = "ACARS Router: A Utility to ingest ACARS/VDLM2 from many sources, process, and feed out to many consumers."
 documentation = "https://github.com/sdr-enthusiasts/acars_router"

--- a/rust/libraries/acars_connection_manager/Cargo.toml
+++ b/rust/libraries/acars_connection_manager/Cargo.toml
@@ -15,5 +15,5 @@ futures = "0.3.24"
 async-trait = "0.1.57"
 zmq = "0.9.2"
 tmq = "0.3.2"
-acars_vdlm2_parser = { git = "https://github.com/jcdeimos/acars_vdlm2_parser", version = "0.1.6" }
+acars_vdlm2_parser = { git = "https://github.com/jcdeimos/acars_vdlm2_parser", version = "0.1.11" }
 acars_config = { path = "../acars_config" }


### PR DESCRIPTION
In lieu of dependabot not supporting 1.64.0, bumping the acars_vdlm2_parser version for latest fixes.