### PR TITLE
Increase log interest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "1.0.18"
+version = "1.0.19"
 authors = ["Fred Clausen", "Mike Nye", "Alex Austin"]
 description = "ACARS Router: A Utility to ingest ACARS/VDLM2 from many sources, process, and feed out to many consumers."
 documentation = "https://github.com/sdr-enthusiasts/acars_router"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ services:
       - AR_SEND_UDP_VDLM2=acarshub:5555
       - AR_RECV_ZMQ_VDLM2=dumpvdl2:45555
       - AR_OVERRIDE_STATION_NAME=${FEEDER_NAME}
+      - AR_STATS_VERBOSE=false
     tmpfs:
       - /run:exec,size=64M
       - /var/log

--- a/rust/libraries/acars_config/src/lib.rs
+++ b/rust/libraries/acars_config/src/lib.rs
@@ -44,6 +44,9 @@ pub struct Input {
     /// Print statistics every N minutes
     #[clap(long, env = "AR_STATS_EVERY", value_parser, default_value = "5")]
     pub stats_every: u64,
+    /// Chatty logging of stats
+    #[clap(long, env = "AR_STATS_VERBOSE", value_parser)]
+    pub stats_verbose: bool,
     /// Attempt message reassembly on incomplete messages within the specified number of seconds
     #[clap(
         long,

--- a/rust/libraries/acars_connection_manager/src/message_handler.rs
+++ b/rust/libraries/acars_connection_manager/src/message_handler.rs
@@ -17,6 +17,11 @@ use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
 
+pub struct FrequencyCount {
+    freq: String,
+    count: u32,
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct MessageHandlerConfig {
     pub add_proxy_id: bool,
@@ -65,6 +70,8 @@ impl MessageHandlerConfig {
             Arc::new(Mutex::new(VecDeque::with_capacity(100)));
         let total_messages_processed: Arc<Mutex<i32>> = Arc::new(Mutex::new(0));
         let total_messages_since_last: Arc<Mutex<i32>> = Arc::new(Mutex::new(0));
+        let all_frequencies_logged: Arc<Mutex<Vec<FrequencyCount>>> =
+            Arc::new(Mutex::new(Vec::new()));
         let queue_type_stats: String = self.queue_type.clone();
         let queue_type_dedupe: String = self.queue_type.clone();
         let stats_every: u64 = self.stats_every * 60; // Value has to be in seconds. Input is in minutes.
@@ -77,11 +84,14 @@ impl MessageHandlerConfig {
         let stats_total_messages_context: Arc<Mutex<i32>> = Arc::clone(&total_messages_processed);
         let stats_total_messages_since_last_context: Arc<Mutex<i32>> =
             Arc::clone(&total_messages_since_last);
+        let stats_frequency_context: Arc<Mutex<Vec<FrequencyCount>>> =
+            Arc::clone(&all_frequencies_logged);
 
         tokio::spawn(async move {
             print_stats(
                 stats_total_messages_context,
                 stats_total_messages_since_last_context,
+                stats_frequency_context,
                 stats_every,
                 queue_type_stats.as_str(),
             )
@@ -131,6 +141,56 @@ impl MessageHandlerConfig {
                         Ok(n) => n.as_secs_f64(),
                         Err(_) => f64::default(),
                     };
+
+                    // See if the frequency is in the list of frequencies we've seen
+                    // If not, add it to the list and log it
+                    // match the message type
+
+                    match &message {
+                        AcarsVdlm2Message::Vdlm2Message(m) => {
+                            // get the freq from Vdlm2Message::Vdlm2Body
+                            let frequency: String = m.vdl2.freq.to_string();
+                            // check and see if we have the frequency in all_frequencies_logged. If so, increment the count.
+                            // if not, add it
+                            let mut found: bool = false;
+                            for freq in all_frequencies_logged.lock().await.iter_mut() {
+                                if freq.freq == frequency {
+                                    freq.count += 1;
+                                    found = true;
+                                    break;
+                                }
+                            }
+
+                            if !found {
+                                let new_frequency: FrequencyCount = FrequencyCount {
+                                    freq: frequency,
+                                    count: 1,
+                                };
+                                all_frequencies_logged.lock().await.push(new_frequency);
+                            }
+                        }
+                        AcarsVdlm2Message::AcarsMessage(m) => {
+                            // get the freq from AcarsMessage::AcarsBody
+                            let frequency: String = m.freq.to_string();
+
+                            let mut found: bool = false;
+                            for freq in all_frequencies_logged.lock().await.iter_mut() {
+                                if freq.freq == frequency {
+                                    freq.count += 1;
+                                    found = true;
+                                    break;
+                                }
+                            }
+
+                            if !found {
+                                let new_frequency: FrequencyCount = FrequencyCount {
+                                    freq: frequency,
+                                    count: 1,
+                                };
+                                all_frequencies_logged.lock().await.push(new_frequency);
+                            }
+                        }
+                    }
 
                     let get_message_time: Option<f64> = message.get_time();
 
@@ -251,15 +311,24 @@ impl MessageHandlerConfig {
 pub async fn print_stats(
     total_all_time: Arc<Mutex<i32>>,
     total_since_last: Arc<Mutex<i32>>,
+    frequencies: Arc<Mutex<Vec<FrequencyCount>>>,
     stats_every: u64,
     queue_type: &str,
 ) {
     let stats_minutes = stats_every / 60;
     loop {
         sleep(Duration::from_secs(stats_every)).await;
+        let total_all_time_locked = *total_all_time.lock().await;
         info!("{} in the last {} minute(s):\nTotal messages processed: {}\nTotal messages processed since last update: {}",
-            queue_type, stats_minutes, total_all_time.lock().await, total_since_last.lock().await);
+            queue_type, stats_minutes, total_all_time_locked, total_since_last.lock().await);
         *total_since_last.lock().await = 0;
+
+        // now print the frequencies, and show each as a percentage of the total_all_time
+
+        for freq in frequencies.lock().await.iter_mut() {
+            let percentage: f64 = (freq.count as f64 / total_all_time_locked as f64) * 100.0;
+            info!("{}: {} ({:.2}%)", freq.freq, freq.count, percentage);
+        }
     }
 }
 

--- a/rust/libraries/acars_connection_manager/src/message_handler.rs
+++ b/rust/libraries/acars_connection_manager/src/message_handler.rs
@@ -322,16 +322,21 @@ pub async fn print_stats(
     loop {
         sleep(Duration::from_secs(stats_every)).await;
         let total_all_time_locked = *total_all_time.lock().await;
-        info!("{} in the last {} minute(s):\nTotal messages processed: {}\nTotal messages processed since last update: {}",
-            queue_type, stats_minutes, total_all_time_locked, total_since_last.lock().await);
+        let mut output: String = String::new();
+        output.push_str(&format!(
+            "{} in the last {} minute(s):\nTotal messages processed: {}\nTotal messages processed since last update: {}\n",
+            queue_type, stats_minutes, total_all_time_locked, total_since_last.lock().await
+        ));
         *total_since_last.lock().await = 0;
 
         // now print the frequencies, and show each as a percentage of the total_all_time
 
         for freq in frequencies.lock().await.iter_mut() {
             let percentage: f64 = (freq.count as f64 / total_all_time_locked as f64) * 100.0;
-            info!("{}: {} ({:.2}%)", freq.freq, freq.count, percentage);
+            output.push_str(format!("{} {}: {}/{} ({:.2}%)\n", queue_type, freq.freq, freq.count, total_all_time_locked, percentage));
         }
+
+        println!("{}", output);
     }
 }
 

--- a/rust/libraries/acars_connection_manager/src/message_handler.rs
+++ b/rust/libraries/acars_connection_manager/src/message_handler.rs
@@ -333,7 +333,13 @@ pub async fn print_stats(
 
         for freq in frequencies.lock().await.iter_mut() {
             let percentage: f64 = (freq.count as f64 / total_all_time_locked as f64) * 100.0;
-            output.push_str(format!("{} {}: {}/{} ({:.2}%)\n", queue_type, freq.freq, freq.count, total_all_time_locked, percentage));
+            output.push_str(
+                format!(
+                    "{} {}: {}/{} ({:.2}%)\n",
+                    queue_type, freq.freq, freq.count, total_all_time_locked, percentage
+                )
+                .as_str(),
+            );
         }
 
         println!("{}", output);

--- a/rust/libraries/acars_connection_manager/src/message_handler.rs
+++ b/rust/libraries/acars_connection_manager/src/message_handler.rs
@@ -87,8 +87,12 @@ impl MessageHandlerConfig {
         let stats_total_messages_context: Arc<Mutex<i32>> = Arc::clone(&total_messages_processed);
         let stats_total_messages_since_last_context: Arc<Mutex<i32>> =
             Arc::clone(&total_messages_since_last);
-        let stats_frequency_context: Arc<Mutex<Vec<FrequencyCount>>> =
-            Arc::clone(&all_frequencies_logged);
+        let stats_frequency_context: Option(Arc<Mutex<Vec<FrequencyCount>>>) = if self.stats_verbose
+        {
+            Some(Arc::clone(&all_frequencies_logged))
+        } else {
+            None
+        };
 
         tokio::spawn(async move {
             print_stats(
@@ -314,7 +318,7 @@ impl MessageHandlerConfig {
 pub async fn print_stats(
     total_all_time: Arc<Mutex<i32>>,
     total_since_last: Arc<Mutex<i32>>,
-    frequencies: Arc<Mutex<Vec<FrequencyCount>>>,
+    frequencies: Option(Arc<Mutex<Vec<FrequencyCount>>>),
     stats_every: u64,
     queue_type: &str,
 ) {
@@ -331,15 +335,22 @@ pub async fn print_stats(
 
         // now print the frequencies, and show each as a percentage of the total_all_time
 
-        for freq in frequencies.lock().await.iter_mut() {
-            let percentage: f64 = (freq.count as f64 / total_all_time_locked as f64) * 100.0;
-            output.push_str(
-                format!(
-                    "{} {}: {}/{} ({:.2}%)\n",
-                    queue_type, freq.freq, freq.count, total_all_time_locked, percentage
-                )
-                .as_str(),
-            );
+        match frequencies {
+            None => {}
+            Some(frequencies) => {
+                // now print the frequencies, and show each as a percentage of the total_all_time
+                for freq in frequencies.lock().await.iter_mut() {
+                    let percentage: f64 =
+                        (freq.count as f64 / total_all_time_locked as f64) * 100.0;
+                    output.push_str(
+                        format!(
+                            "{} {}: {}/{} ({:.2}%)\n",
+                            queue_type, freq.freq, freq.count, total_all_time_locked, percentage
+                        )
+                        .as_str(),
+                    );
+                }
+            }
         }
 
         println!("{}", output);

--- a/rust/libraries/acars_connection_manager/src/message_handler.rs
+++ b/rust/libraries/acars_connection_manager/src/message_handler.rs
@@ -32,6 +32,7 @@ pub struct MessageHandlerConfig {
     pub should_override_station_name: bool,
     pub station_name: String,
     pub stats_every: u64,
+    pub stats_verbose: bool,
 }
 
 impl MessageHandlerConfig {
@@ -46,6 +47,7 @@ impl MessageHandlerConfig {
                 should_override_station_name: args.override_station_name.is_some(),
                 station_name: station_name.to_string(),
                 stats_every: args.stats_every,
+                stats_verbose: args.stats_verbose,
             }
         } else {
             Self {
@@ -57,6 +59,7 @@ impl MessageHandlerConfig {
                 should_override_station_name: false,
                 station_name: Default::default(),
                 stats_every: args.stats_every,
+                stats_verbose: args.stats_verbose,
             }
         }
     }

--- a/rust/libraries/acars_connection_manager/src/message_handler.rs
+++ b/rust/libraries/acars_connection_manager/src/message_handler.rs
@@ -336,7 +336,12 @@ pub async fn print_stats(
         // now print the frequencies, and show each as a percentage of the total_all_time
 
         if let Some(f) = &frequencies {
-            for freq in f.lock().await.iter_mut() {
+            // sort the frequencies by count
+            if let Some(f) = &frequencies {
+                f.lock().await.sort_by(|a, b| b.count.cmp(&a.count));
+            }
+
+            for freq in f.lock().await.iter() {
                 let percentage: f64 = (freq.count as f64 / total_all_time_locked as f64) * 100.0;
                 output.push_str(
                     format!(

--- a/rust/libraries/acars_connection_manager/src/message_handler.rs
+++ b/rust/libraries/acars_connection_manager/src/message_handler.rs
@@ -87,7 +87,7 @@ impl MessageHandlerConfig {
         let stats_total_messages_context: Arc<Mutex<i32>> = Arc::clone(&total_messages_processed);
         let stats_total_messages_since_last_context: Arc<Mutex<i32>> =
             Arc::clone(&total_messages_since_last);
-        let stats_frequency_context: Option(Arc<Mutex<Vec<FrequencyCount>>>) = if self.stats_verbose
+        let stats_frequency_context: Option<Arc<Mutex<Vec<FrequencyCount>>>> = if self.stats_verbose
         {
             Some(Arc::clone(&all_frequencies_logged))
         } else {
@@ -318,7 +318,7 @@ impl MessageHandlerConfig {
 pub async fn print_stats(
     total_all_time: Arc<Mutex<i32>>,
     total_since_last: Arc<Mutex<i32>>,
-    frequencies: Option(Arc<Mutex<Vec<FrequencyCount>>>),
+    frequencies: Option<Arc<Mutex<Vec<FrequencyCount>>>>,
     stats_every: u64,
     queue_type: &str,
 ) {
@@ -335,21 +335,16 @@ pub async fn print_stats(
 
         // now print the frequencies, and show each as a percentage of the total_all_time
 
-        match frequencies {
-            None => {}
-            Some(frequencies) => {
-                // now print the frequencies, and show each as a percentage of the total_all_time
-                for freq in frequencies.lock().await.iter_mut() {
-                    let percentage: f64 =
-                        (freq.count as f64 / total_all_time_locked as f64) * 100.0;
-                    output.push_str(
-                        format!(
-                            "{} {}: {}/{} ({:.2}%)\n",
-                            queue_type, freq.freq, freq.count, total_all_time_locked, percentage
-                        )
-                        .as_str(),
-                    );
-                }
+        if let Some(f) = &frequencies {
+            for freq in f.lock().await.iter_mut() {
+                let percentage: f64 = (freq.count as f64 / total_all_time_locked as f64) * 100.0;
+                output.push_str(
+                    format!(
+                        "{} {}: {}/{} ({:.2}%)\n",
+                        queue_type, freq.freq, freq.count, total_all_time_locked, percentage
+                    )
+                    .as_str(),
+                );
             }
         }
 


### PR DESCRIPTION
Add `AR_STATS_VERBOSE`/`--stats_verbose`, which will enable extra logging of interesting stats. At the moment, the only such statistic that is shown will be a breakdown of all received frequencies as a percentage of the total for that decoder type.

Example

```
ACARS in the last 1 minute(s):
Total messages processed: 2444
Total messages processed since last update: 3
ACARS 130.025: 1638/2444 (67.02%)
ACARS 131.725: 113/2444 (4.62%)
ACARS 131.55: 434/2444 (17.76%)
ACARS 130.425: 3/2444 (0.12%)
ACARS 129.525: 171/2444 (7.00%)
ACARS 129.9: 21/2444 (0.86%)
ACARS 129.35: 20/2444 (0.82%)
ACARS 129: 21/2444 (0.86%)
ACARS 130.825: 2/2444 (0.08%)
ACARS 129.125: 15/2444 (0.61%)
ACARS 131.525: 2/2444 (0.08%)
ACARS 131.85: 1/2444 (0.04%)
ACARS 131.25: 1/2444 (0.04%)
ACARS 130.85: 1/2444 (0.04%)
ACARS 130.45: 1/2444 (0.04%)

VDLM in the last 1 minute(s):
Total messages processed: 4524
Total messages processed since last update: 5
VDLM 136975000: 3842/4524 (84.92%)
VDLM 136800000: 422/4524 (9.33%)
VDLM 136650000: 242/4524 (5.35%)
VDLM 136945000: 14/4524 (0.31%)
VDLM 136825000: 4/4524 (0.09%)
```