### PR TITLE
More verbose logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "1.0.19"
+version = "1.0.20"
 authors = ["Fred Clausen", "Mike Nye", "Alex Austin"]
 description = "ACARS Router: A Utility to ingest ACARS/VDLM2 from many sources, process, and feed out to many consumers."
 documentation = "https://github.com/sdr-enthusiasts/acars_router"

--- a/rust/libraries/acars_connection_manager/Cargo.toml
+++ b/rust/libraries/acars_connection_manager/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stubborn-io = "0.3.2"
+stubborn-io = { git = "https://github.com/sdr-enthusiasts/sdre-stubborn-io.git" }
 log = "0.4.20"
 tokio = { version = "1.34.0", features = ["full", "tracing"] }
 tokio-util = { version = "0.7.10", features = ["full"] }

--- a/rust/libraries/acars_connection_manager/src/lib.rs
+++ b/rust/libraries/acars_connection_manager/src/lib.rs
@@ -94,10 +94,11 @@ pub(crate) struct OutputServerConfig {
 // to attempt to reconnect
 // See: https://docs.rs/stubborn-io/latest/src/stubborn_io/config.rs.html#93
 
-pub fn reconnect_options() -> ReconnectOptions {
+pub fn reconnect_options(host: &str) -> ReconnectOptions {
     ReconnectOptions::new()
         .with_exit_if_first_connect_fails(false)
         .with_retries_generator(get_our_standard_reconnect_strategy)
+        .with_connection_name(host)
 }
 
 fn get_our_standard_reconnect_strategy() -> DurationIterator {

--- a/rust/libraries/acars_connection_manager/src/message_handler.rs
+++ b/rust/libraries/acars_connection_manager/src/message_handler.rs
@@ -397,7 +397,7 @@ pub async fn print_stats(
             freqs_locked = Some(freqs);
         }
 
-        println!(
+        info!(
             "{}",
             print_formatted_stats(
                 total_all_time_locked,

--- a/rust/libraries/acars_connection_manager/src/message_handler.rs
+++ b/rust/libraries/acars_connection_manager/src/message_handler.rs
@@ -330,12 +330,15 @@ pub fn print_formatted_stats(
         ));
 
     if has_counted_freqs && frequencies.is_some() {
+        output.push_str(
+            format!("{} Frequencies logged since container start:\n", queue_type).as_str(),
+        );
         if let Some(freqs) = frequencies {
             for freq in freqs.iter() {
                 let percentage: f64 = (freq.count as f64 / total_all_time as f64) * 100.0;
                 output.push_str(
                     format!(
-                        "\n{} {}: {}/{} ({:.2}%)\n",
+                        "\n{} {}: {}/{} ({:.2}%)",
                         queue_type, freq.freq, freq.count, total_all_time, percentage
                     )
                     .as_str(),
@@ -511,7 +514,7 @@ mod tests {
 
         assert_eq!(
             output_with_extra_stats,
-            "TEST in the last 1 minute(s):\nTotal messages processed: 100\nTotal messages processed since last update: 100\n\nTEST 134.525: 70/100 (70.00%)\n\nTEST 131.550: 20/100 (20.00%)\n\nTEST 131.525: 10/100 (10.00%)\n"
+            "TEST in the last 1 minute(s):\nTotal messages processed: 100\nTotal messages processed since last update: 100\nTEST Frequencies logged since container start:\n\nTEST 134.525: 70/100 (70.00%)\nTEST 131.550: 20/100 (20.00%)\nTEST 131.525: 10/100 (10.00%)"
         );
 
         let output_without_extra_stats = print_formatted_stats(

--- a/rust/libraries/acars_connection_manager/src/service_init.rs
+++ b/rust/libraries/acars_connection_manager/src/service_init.rs
@@ -475,7 +475,8 @@ impl SenderServers for Arc<Mutex<Vec<Sender<AcarsVdlm2Message>>>> {
     async fn start_tcp(self, socket_type: &str, host: &str) {
         // Start a TCP sender server for {server_type}
         let socket: Result<StubbornIo<TcpStream, String>, io::Error> =
-            StubbornTcpStream::connect_with_options(host.to_string(), reconnect_options()).await;
+            StubbornTcpStream::connect_with_options(host.to_string(), reconnect_options(host))
+                .await;
         match socket {
             Err(e) => error!("[TCP SENDER {socket_type}]: Error connecting to {host}: {e}"),
             Ok(socket) => {
@@ -537,7 +538,7 @@ impl SocketListenerServer {
                         let open_stream: io::Result<StubbornIo<TcpStream, SocketAddr>> =
                             StubbornTcpStream::connect_with_options(
                                 socket_address,
-                                reconnect_options(),
+                                reconnect_options(&self.proto_name),
                             )
                             .await;
                         match open_stream {

--- a/rust/libraries/acars_connection_manager/src/tcp_services.rs
+++ b/rust/libraries/acars_connection_manager/src/tcp_services.rs
@@ -180,7 +180,11 @@ impl TCPReceiverServer {
             }
         };
 
-        let stream = match StubbornTcpStream::connect_with_options(addr, reconnect_options()).await
+        let stream = match StubbornTcpStream::connect_with_options(
+            addr,
+            reconnect_options(&self.proto_name),
+        )
+        .await
         {
             Ok(stream) => stream,
             Err(e) => {


### PR DESCRIPTION
Switch to using the SDR-E fork of Stubborn IO. This fork now includes the ability to pass in a label/name for the connection and use that name during logging events so the user can see what connection(s) has died.