### PR TITLE
TCP receive client: fix non-reconnect if the connection drops irreguarly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "futures",
  "log",
  "sdre-stubborn-io",
+ "socket2",
  "tmq",
  "tokio",
  "tokio-stream",
@@ -38,6 +39,7 @@ dependencies = [
  "sdre-rust-logging",
  "serde",
  "serde_json",
+ "socket2",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1.0.142"
 sdre-rust-logging = "0.3.21"
 clap = { version = "4.5.43", features = ["derive", "env"] }
 sdre-stubborn-io = "0.6.11"
+socket2 = "0.6.0"
 tokio-util = { version = "0.7.16", features = ["full"] }
 tokio-stream = "0.1.17"
 futures = "0.3.31"

--- a/rust/bin/acars_router/Cargo.toml
+++ b/rust/bin/acars_router/Cargo.toml
@@ -19,3 +19,4 @@ tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sdre-rust-logging.workspace = true
+socket2.workspace = true

--- a/rust/libraries/acars_connection_manager/Cargo.toml
+++ b/rust/libraries/acars_connection_manager/Cargo.toml
@@ -18,5 +18,6 @@ futures.workspace = true
 async-trait.workspace = true
 zmq.workspace = true
 tmq.workspace = true
+socket2.workspace = true
 #acars_vdlm2_parser = { git = "https://github.com/jcdeimos/acars_vdlm2_parser", version = "0.2.1" }
 #acars_vdlm2_parser = { git = "https://github.com/fredclausen/acars_vdlm2_parser", branch = "hfdl-and-dependency-updates" }

--- a/rust/libraries/acars_connection_manager/src/tcp_services.rs
+++ b/rust/libraries/acars_connection_manager/src/tcp_services.rs
@@ -21,6 +21,7 @@ use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, Mutex, MutexGuard};
 use tokio_stream::StreamExt;
 use tokio_util::codec::{Framed, LinesCodec};
+use std::time::Duration;
 
 use crate::packet_handler::{PacketHandler, ProcessAssembly};
 use crate::{reconnect_options, Rx, SenderServer, Shared};
@@ -199,6 +200,16 @@ impl TCPReceiverServer {
                 Err(e)?
             }
         };
+
+        // Set TCP KeepAlive
+
+        let sock_ref = socket2::SockRef::from(&*stream);
+
+        let mut ka = socket2::TcpKeepalive::new();
+        ka = ka.with_time(Duration::from_secs(5));
+        ka = ka.with_interval(Duration::from_secs(5));
+
+        sock_ref.set_tcp_keepalive(&ka)?;
 
         // create a buffered reader and send the messages to the channel
 


### PR DESCRIPTION
for example the power of the box you're connected to cuts out TCP KeepAlive will make stubbornIO notice that the connection is actually dead vs just staying established indefinitely while the other side isn't actually there