### PR TITLE
chore(flake/nixpkgs): `6201e203` -> `4c1018da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`5c1ce9a4`](https://github.com/NixOS/nixpkgs/commit/5c1ce9a451d2b0b4c671e255fa8b56453bc7a6c5) | `` downkyicore: 1.0.23 -> 1.0.24 ``                                                       |
| [`2189e6be`](https://github.com/NixOS/nixpkgs/commit/2189e6beeddff6dd451b844caa5fd18bc283283f) | `` lmstudio: 0.4.9.1 -> 0.4.10.1 ``                                                       |
| [`27f560a7`](https://github.com/NixOS/nixpkgs/commit/27f560a7e9df90233563c5881fcd75f5b1c78d3c) | `` flow: 0.305.1 -> 0.308.0 ``                                                            |
| [`853daad4`](https://github.com/NixOS/nixpkgs/commit/853daad4347a6017154eda6078a11d01eab3afee) | `` terraform-providers.hashicorp_tfe: 0.76.0 -> 0.76.1 ``                                 |
| [`a3da496e`](https://github.com/NixOS/nixpkgs/commit/a3da496ee6f15eaea04d19a67a8362fd7b6d1128) | `` terraform-providers.spotinst_spotinst: 1.232.5 -> 1.233.1 ``                           |
| [`2ba31cc8`](https://github.com/NixOS/nixpkgs/commit/2ba31cc82b06db582f59819de282eb65ede8538a) | `` lockbook: 26.3.22 -> 26.4.8 ``                                                         |
| [`62352661`](https://github.com/NixOS/nixpkgs/commit/6235266151b6cdeaeba640a65637d8f40378d1f0) | `` syft: 1.42.3 -> 1.42.4 ``                                                              |
| [`bdd981fa`](https://github.com/NixOS/nixpkgs/commit/bdd981fa1c433e8dc848623341feb1dd9696b8f5) | `` chatmcp: drop ``                                                                       |
| [`05889e87`](https://github.com/NixOS/nixpkgs/commit/05889e872510746343c47c333f661b87abba3a8c) | `` python3Packages.cyvest: 5.4.0 -> 5.4.1 ``                                              |
| [`68e93a76`](https://github.com/NixOS/nixpkgs/commit/68e93a7622de79278189673ea692f2dae4467f44) | `` python3Packages.xgrammar: remove aarch64-linux from meta.badPlatforms ``               |
| [`5795e6d5`](https://github.com/NixOS/nixpkgs/commit/5795e6d577cce22b374049f972d36a80fa344d8d) | `` python3Packages.mlx-vlm: 0.4.2 -> 0.4.4 ``                                             |
| [`156e6799`](https://github.com/NixOS/nixpkgs/commit/156e6799b49533a560167d16b1d493e176afb12f) | `` nixos/nvidia: fix videoAcceleration option description ``                              |
| [`3e2ee6a2`](https://github.com/NixOS/nixpkgs/commit/3e2ee6a2000a69fca1d4027735d29f8af16ef507) | `` macmon: add nix-update-script ``                                                       |
| [`fe1f3599`](https://github.com/NixOS/nixpkgs/commit/fe1f35992748181faa8f4ceae534c30ef06b7112) | `` python3Packages.pylutron-caseta: migrate to finalAttrs ``                              |
| [`43ec484c`](https://github.com/NixOS/nixpkgs/commit/43ec484cac55a60dc938a390b3f1298dcd2331e3) | `` python3Packages.llama-index-cli: 0.5.6 -> 0.5.7 ``                                     |
| [`1f6c203c`](https://github.com/NixOS/nixpkgs/commit/1f6c203c6eac0e0cc9aadf7227a55a6453bfcb6b) | `` python3Packages.mlx-lm: 0.31.1 -> 0.31.2 ``                                            |
| [`079fad6e`](https://github.com/NixOS/nixpkgs/commit/079fad6ecbf131d05ba12b338668dc8448633c96) | `` stylua: 2.4.0 -> 2.4.1 ``                                                              |
| [`ee8ab668`](https://github.com/NixOS/nixpkgs/commit/ee8ab6689ac43352b3853c67b77363dadb93fb08) | `` ggml: 0.9.9 -> 0.9.11 ``                                                               |
| [`6cc4c210`](https://github.com/NixOS/nixpkgs/commit/6cc4c210ad2b5be399fdd26c3c39eda54bb699d9) | `` opentofu: 1.11.5 -> 1.11.6 ``                                                          |
| [`160c5472`](https://github.com/NixOS/nixpkgs/commit/160c5472d2544d2d2a05178012256a5dda97ded4) | `` search-vulns: 1.0.8 -> 1.0.9 ``                                                        |
| [`7368396e`](https://github.com/NixOS/nixpkgs/commit/7368396e53254f6dd78babf7272754b8741bc777) | `` pretix: 2026.3.0 -> 2026.3.1 ``                                                        |
| [`69203d07`](https://github.com/NixOS/nixpkgs/commit/69203d07d91cd8d5f29fa7ae824682b62c5efce1) | `` vimPlugins.codediff-nvim: fix library build on Darwin ``                               |
| [`fd6fece0`](https://github.com/NixOS/nixpkgs/commit/fd6fece00d41e2f10c2649cdd12138db0b0f5229) | `` vimPlugins: update on 2026-04-08 ``                                                    |
| [`5a41a0e5`](https://github.com/NixOS/nixpkgs/commit/5a41a0e587e211a1ffdfebeb479f71eb23d113e1) | `` pinta: 3.1.1 -> 3.1.2 ``                                                               |
| [`d9aa992e`](https://github.com/NixOS/nixpkgs/commit/d9aa992ed94fc520f2c4c2b7d152c47f0dcba442) | `` luaPackages: update on 2026-04-08 ``                                                   |
| [`088bee87`](https://github.com/NixOS/nixpkgs/commit/088bee87ed9ad82027c1ffcd0eb1cd6380b2b10a) | `` yaziPlugins: update on 2026-04-08 ``                                                   |
| [`0778e330`](https://github.com/NixOS/nixpkgs/commit/0778e330e5e15914e41db72d3b4b3aa533e79602) | `` python3Packages.crewai: 1.13.0 -> 1.14.1 ``                                            |
| [`b6e7129f`](https://github.com/NixOS/nixpkgs/commit/b6e7129fb218ccec8f2db9913eccb641e32d4357) | `` stevenblack-blocklist: 3.16.72 -> 3.16.74 ``                                           |
| [`8b6541a2`](https://github.com/NixOS/nixpkgs/commit/8b6541a2d636dee32d8f03398b113fd119369108) | `` libretro.genesis-plus-gx: 0-unstable-2026-03-31 -> 0-unstable-2026-04-03 ``            |
| [`1c6df90d`](https://github.com/NixOS/nixpkgs/commit/1c6df90d4f9ddf5bc4e29e3315924622519dd658) | `` home-assistant-custom-components.gtfs-realtime: 0.4.4 -> 0.4.6 ``                      |
| [`d1f4975f`](https://github.com/NixOS/nixpkgs/commit/d1f4975fce7cc116d4c5a52aaa15e3dc3f1d31f0) | `` cockpit: 359 -> 360 ``                                                                 |
| [`faa8312c`](https://github.com/NixOS/nixpkgs/commit/faa8312c04e7b9c5fd7c101f0a42b2627d055323) | `` python3Packages.pylutron-caseta: 0.27.0 -> 0.28.0 ``                                   |
| [`6fd18655`](https://github.com/NixOS/nixpkgs/commit/6fd18655ac93a596def2fc68181480895f2982f5) | `` prisma_7, prisma-engines_7: 7.6.0 -> 7.7.0 ``                                          |
| [`12be7326`](https://github.com/NixOS/nixpkgs/commit/12be73268caacd2e3bf9d7eac3ebcbba24cf604b) | `` vimPlugins.nvim-jump: init at 0-unstable-2026-04-08 ``                                 |
| [`2b00f2ee`](https://github.com/NixOS/nixpkgs/commit/2b00f2ee6b7d1bb16bc3787263241e62ec92f352) | `` pyrefly: 0.58.0 -> 0.60.0 ``                                                           |
| [`59d07119`](https://github.com/NixOS/nixpkgs/commit/59d07119c3dad875567a9f1cd9159619e45de925) | `` python3Packages.zcc-helper: 3.7 -> 3.8 ``                                              |
| [`f1422919`](https://github.com/NixOS/nixpkgs/commit/f1422919651904ea83ab3299307b5c306498394c) | `` batman-adv: 2026.0 -> 2026.1 ``                                                        |
| [`81525544`](https://github.com/NixOS/nixpkgs/commit/81525544555a7179bad90e46991a180cf58c2597) | `` mqtt-randompub: 0.4.0 -> 0.5.1 ``                                                      |
| [`57f5ac45`](https://github.com/NixOS/nixpkgs/commit/57f5ac4558f5ef8c0b6aa999111fa0932ba7f2b4) | `` pyenv: 2.6.26 -> 2.6.27 ``                                                             |
| [`a9eb894a`](https://github.com/NixOS/nixpkgs/commit/a9eb894a69032f302845762f30ff4aed52af70f4) | `` vscode-extensions.github.vscode-pull-request-github: 0.132.2 -> 0.134.0 ``             |
| [`d454e275`](https://github.com/NixOS/nixpkgs/commit/d454e275cb0aef15f585d961cf6a40038a611532) | `` terraform-providers.hashicorp_google-beta: 7.25.0 -> 7.27.0 ``                         |
| [`dd0017c9`](https://github.com/NixOS/nixpkgs/commit/dd0017c90e11d1977d4058d7b456ae2f4dc8aeb6) | `` opensmtpd: fix missing braces in proc_path.diff for fork_filter_process ``             |
| [`0e1c5489`](https://github.com/NixOS/nixpkgs/commit/0e1c5489b51e92aba6f370ce1dd55ec0caefcce9) | `` ungoogled-chromium: 146.0.7680.177-1 -> 147.0.7727.55-1 ``                             |
| [`dfbd61a9`](https://github.com/NixOS/nixpkgs/commit/dfbd61a9d45c461d15e3b9da3acc24aeb034d9ca) | `` python3Packages.streamz: 0.6.5 -> 0.6.6 ``                                             |
| [`53b26ef0`](https://github.com/NixOS/nixpkgs/commit/53b26ef0f855185ca8993f6b9efa71fb2dbc8f9a) | `` vscode-extensions.discloud.discloud: 2.28.3 -> 2.28.4 ``                               |
| [`a4a2d20a`](https://github.com/NixOS/nixpkgs/commit/a4a2d20aa1ab1721d9f2933a935787b8e74e2309) | `` gh-cherry-pick: init at 1.2.0 ``                                                       |
| [`02648ba9`](https://github.com/NixOS/nixpkgs/commit/02648ba9d9cf0191ed9f71a1b3c57c08f4164d4a) | `` tango-cpp: 10.1.2 -> 10.3.0 ``                                                         |
| [`5cb7193b`](https://github.com/NixOS/nixpkgs/commit/5cb7193be3562f74b8d3036e2d453f9b102691e4) | `` age-plugin-yubikey: 0.5.0-unstable-2024-11-02 -> 0.5.1 ``                              |
| [`2834b1a7`](https://github.com/NixOS/nixpkgs/commit/2834b1a7590bc73f2881343d93ec170e06cf4ae7) | `` github-runner: only disable __noChroot on linux ``                                     |
| [`19b47600`](https://github.com/NixOS/nixpkgs/commit/19b476004e07351933e646196294d04ad11ab3bb) | `` python3Packages.tensordict: skip failing tests on aarch64-linux ``                     |
| [`b364f8fe`](https://github.com/NixOS/nixpkgs/commit/b364f8fe9b615505489282ceaadbbebdd41f445e) | `` alfis: fix `Failed to load ayatana-appindicator3 or appindicator3 dynamic library` ``  |
| [`438324d1`](https://github.com/NixOS/nixpkgs/commit/438324d1de5d73c0929a2e8fe9f5b2ee15f7ba98) | `` uv: 0.11.3 -> 0.11.4 ``                                                                |
| [`fdd5d36b`](https://github.com/NixOS/nixpkgs/commit/fdd5d36b99549cae08c36db3a79680f8497050ae) | `` alfis: add xdotool to buildInputs ``                                                   |
| [`2047b739`](https://github.com/NixOS/nixpkgs/commit/2047b739a89ad07e7925c9d151ce740b84d45127) | `` csharp-ls: 0.22.0 -> 0.23.0 ``                                                         |
| [`c422f243`](https://github.com/NixOS/nixpkgs/commit/c422f2430c194a2fdcf7737e7db78088278cf56b) | `` just-lsp: 0.4.0 -> 0.4.1 ``                                                            |
| [`8e87791d`](https://github.com/NixOS/nixpkgs/commit/8e87791dc894515f9901bbcf5f4b1d8a52079046) | `` python3Packages.tensordict: fix hash ``                                                |
| [`68394eb5`](https://github.com/NixOS/nixpkgs/commit/68394eb51f22593c618021b064e41e8d76698c2b) | `` turingdb: 1.26 -> 1.28 ``                                                              |
| [`ca08ede4`](https://github.com/NixOS/nixpkgs/commit/ca08ede44d3e712d720448126aef3161191660de) | `` xdg-desktop-portal: 1.20.3 -> 1.20.4 ``                                                |
| [`706eb82e`](https://github.com/NixOS/nixpkgs/commit/706eb82e3fd3f721b372982d90713b84c11dc332) | `` paratest: 7.20.0 -> 7.22.2 ``                                                          |
| [`8c5d8cf8`](https://github.com/NixOS/nixpkgs/commit/8c5d8cf89460a92843a0d06edb323d8143d0b339) | `` apt: 3.1.16 -> 3.2.0 ``                                                                |
| [`cf6a3f05`](https://github.com/NixOS/nixpkgs/commit/cf6a3f05579bfa6058abce05a2b6548d8d7e557f) | `` tirith: 0.2.10 -> 0.2.12 ``                                                            |
| [`4beaa04e`](https://github.com/NixOS/nixpkgs/commit/4beaa04ec4ef2b200031c4d8a76e9941287a337c) | `` chromium,chromedriver: 146.0.7680.177 -> 147.0.7727.55 ``                              |
| [`66fbf99f`](https://github.com/NixOS/nixpkgs/commit/66fbf99f3004d569fe691918707c172c734f8aa5) | `` python3Packages.rmscene: 0.7.0 -> 0.8.0 ``                                             |
| [`5fdb0f13`](https://github.com/NixOS/nixpkgs/commit/5fdb0f13095745f74f42bf5926e3db7abad9090f) | `` python3Packages.scikit-hep-testdata: 0.6.4 -> 0.6.5 ``                                 |
| [`44d0817e`](https://github.com/NixOS/nixpkgs/commit/44d0817e8013f722962e6b45d6640775d2ce0a55) | `` vimPlugins.rainbow-delimiters-nvim: 0.11.0 -> 0.12.0 ``                                |
| [`5c6a7d99`](https://github.com/NixOS/nixpkgs/commit/5c6a7d995739b0e01794e29e276cb0f909a1a6bd) | `` vscode-extensions.leanprover.lean4: 0.0.226 -> 0.0.229 ``                              |
| [`47acf715`](https://github.com/NixOS/nixpkgs/commit/47acf715023a954d2e6614245ee6d62b957eda50) | `` rclone: 1.73.3 -> 1.73.4 ``                                                            |
| [`239fe781`](https://github.com/NixOS/nixpkgs/commit/239fe781613b299dec7cd1c76c2d46e7ed56212f) | `` python3Packages.expiringdict: remove gravndal from maintainers ``                      |
| [`7099e93a`](https://github.com/NixOS/nixpkgs/commit/7099e93a911ba81753f8138a8d6ac1f758870b2e) | `` python3Packages.drivelib: remove gravndal from maintainers ``                          |
| [`a01485ee`](https://github.com/NixOS/nixpkgs/commit/a01485eeac9d4c018d86d625ff3346c75606c091) | `` git-annex-remote-googledrive: remove gravndal from maintainers ``                      |
| [`9ba76df3`](https://github.com/NixOS/nixpkgs/commit/9ba76df33a579a6e742ab0a0afc616c24295e98b) | `` shtab: use finalAttrs ``                                                               |
| [`b050c15a`](https://github.com/NixOS/nixpkgs/commit/b050c15a4a2b815bdd1aa7dee3c37a2a2e0ea9b9) | `` androidenv.ndk-bundle: use jdk_headless instead of jdk ``                              |
| [`b1f9d94c`](https://github.com/NixOS/nixpkgs/commit/b1f9d94ce8cfa4d30dae80433f0d3056c62e7b4c) | `` opencode{,-desktop}: 1.3.13 -> 1.4.0 ``                                                |
| [`78b37a61`](https://github.com/NixOS/nixpkgs/commit/78b37a61b5cb6dcb8b799d6f8ef6b9cdb062ee3d) | `` nginx-sso: 0.27.6 -> 0.27.7 ``                                                         |
| [`d3d6df9d`](https://github.com/NixOS/nixpkgs/commit/d3d6df9dca94f000a2be5414515faac3ad59558a) | `` rerun: 0.31.1 -> 0.31.2 ``                                                             |
| [`bcf452b5`](https://github.com/NixOS/nixpkgs/commit/bcf452b59696ea429bce8cfd07dc796f8accc1ac) | `` okteto: 3.17.1 -> 3.18.0 ``                                                            |
| [`5f58d58f`](https://github.com/NixOS/nixpkgs/commit/5f58d58f027bbb4f0436d5e7c94e17c009fb511d) | `` home-assistant-custom-components.midea_ac: 2026.2.0 -> 2026.4.0 ``                     |
| [`fb59de3b`](https://github.com/NixOS/nixpkgs/commit/fb59de3bab599d67e530edb6b5bacdb34fa85431) | `` python3Packages.msmart-ng: 2025.12.0 -> 2026.4.1 ``                                    |
| [`112f0cc8`](https://github.com/NixOS/nixpkgs/commit/112f0cc8a89c23f2078eed10e5bc82ba75088545) | `` goshs: 1.1.4 -> 2.0.0-beta.3 ``                                                        |
| [`5563853e`](https://github.com/NixOS/nixpkgs/commit/5563853eb54dc3aa6cf38f7af3f1656b7ced66fd) | `` rustic: 0.11.1 -> 0.11.2 ``                                                            |
| [`e1c5eaa9`](https://github.com/NixOS/nixpkgs/commit/e1c5eaa9f923efe5044d4554bc2d911d47796f91) | `` rembg: 2.0.74 -> 2.0.75 ``                                                             |
| [`7a9bf277`](https://github.com/NixOS/nixpkgs/commit/7a9bf2776062731e82a6bf0a6b41fdcdf44623a5) | `` nix-required-mounts: Mount symlink children's targets and add tests ``                 |
| [`928e943a`](https://github.com/NixOS/nixpkgs/commit/928e943ab4872f0b0c10696468e5c0b0f9656127) | `` rmw: 0.9.4 -> 0.9.5 ``                                                                 |
| [`54c0055c`](https://github.com/NixOS/nixpkgs/commit/54c0055c7f10116b42934b234faa481f9c173b2d) | `` python3Packages.einx: 0.4.2 -> 0.4.3 ``                                                |
| [`94fa9d4b`](https://github.com/NixOS/nixpkgs/commit/94fa9d4b65ad8e44255f38a9790c9e0137c55a7c) | `` snid: add modular service and test ``                                                  |
| [`38ce1571`](https://github.com/NixOS/nixpkgs/commit/38ce1571aa9d6b7bf171fb0ab0e2bf84e73245ef) | `` python3Packages.pyprecice: 3.3.1 -> 3.4.0 ``                                           |
| [`4f9dbfd4`](https://github.com/NixOS/nixpkgs/commit/4f9dbfd48bdd4803d5de1a7152e8b434e9023e77) | `` redumper: 706 -> 708 ``                                                                |
| [`c2085922`](https://github.com/NixOS/nixpkgs/commit/c20859229dea656bdfb4ea0882d2e38568b4f39d) | `` sandbox-runtime: 0.0.44 -> 0.0.49 ``                                                   |
| [`0c1f67e5`](https://github.com/NixOS/nixpkgs/commit/0c1f67e5fcaa8ab5971c1ae1989a27c0528b602d) | `` python3Packages.hyponcloud: 0.9.1 -> 0.9.3 ``                                          |
| [`716d1202`](https://github.com/NixOS/nixpkgs/commit/716d1202c91ee02d6b9f3a281491becf17a9bc46) | `` mise: 2026.3.17 -> 2026.4.6 ``                                                         |
| [`f81cee4d`](https://github.com/NixOS/nixpkgs/commit/f81cee4d94d491578858597c1621722649d703f1) | `` python3Packages.tinygrad: skip failing tests on aarch64-linux ``                       |
| [`0e54761c`](https://github.com/NixOS/nixpkgs/commit/0e54761c927423fbab652eec964eca359f5c1e0b) | `` ec: add neo as maintainer ``                                                           |
| [`32b47224`](https://github.com/NixOS/nixpkgs/commit/32b4722497080ac249ce8b40f23c0a8cb8f57eb4) | `` ec: 0.2.0 -> 0.3.1 ``                                                                  |
| [`dd16d502`](https://github.com/NixOS/nixpkgs/commit/dd16d5029d6164ee2da061f5a78fbe52fae112b2) | `` maintainers: add neo ``                                                                |
| [`7e43cdd4`](https://github.com/NixOS/nixpkgs/commit/7e43cdd4556d2ba66dea5c15312614e987025d30) | `` python3Packages.pylutron: migrate to finalAttrs ``                                     |
| [`27868c8c`](https://github.com/NixOS/nixpkgs/commit/27868c8c5c0a18be46ce78cd0d4366425f6bc3cc) | `` python3Packages.pylutron: 0.4.0 -> 0.4.1 ``                                            |
| [`d3b853bd`](https://github.com/NixOS/nixpkgs/commit/d3b853bd1070b74977a629ed2ceff0735f5bbae8) | `` python3Packages.incomfort-client: 0.6.12 -> 0.7.0 ``                                   |
| [`e4c28200`](https://github.com/NixOS/nixpkgs/commit/e4c282009849a53314c7e70c45a0248ac01cdbed) | `` python3Packages.aiohomeconnect: 0.33.0 -> 0.34.0 ``                                    |
| [`1d13f850`](https://github.com/NixOS/nixpkgs/commit/1d13f8506bbbcd1a5576f1569504863c9eeb032a) | `` trufflehog: 3.94.1 -> 3.94.2 ``                                                        |
| [`f18e60d4`](https://github.com/NixOS/nixpkgs/commit/f18e60d4ed03fa2e4db9fd02c38064718ab0f49f) | `` python3Packages.arc4: modernize ``                                                     |
| [`aea65fab`](https://github.com/NixOS/nixpkgs/commit/aea65fab4aec5542ccf6ccafdebe3f30147ddf99) | `` python3Packages.xiaomi-ble: 1.10.0 -> 1.10.1 ``                                        |
| [`a1ce422e`](https://github.com/NixOS/nixpkgs/commit/a1ce422efbb98b5a67e265a13c7f496b1d3dbe18) | `` python3Packages.arc4: 0.4.0 -> 0.5.0 ``                                                |
| [`973cfb61`](https://github.com/NixOS/nixpkgs/commit/973cfb6118e1d42026494690de3e5473cec5ba52) | `` python3Packages.nomadnet: 0.9.8 -> 0.9.9 ``                                            |
| [`89eb4961`](https://github.com/NixOS/nixpkgs/commit/89eb496163afae288c21a8ad73814ec3e06e0b21) | `` python3Packages.tencentcloud-sdk-python: 3.1.71 -> 3.1.72 ``                           |
| [`32a3d256`](https://github.com/NixOS/nixpkgs/commit/32a3d256d232fd586b5dbbd6fdeb5334042aedbd) | `` python3Packages.publicsuffixlist: 1.0.2.20260403 -> 1.0.2.20260408 ``                  |
| [`be6c480e`](https://github.com/NixOS/nixpkgs/commit/be6c480e2d1e7c74f9097a3bd11328f1a4730bbf) | `` python314Packages.boto3-stubs: 1.42.83 -> 1.42.85 ``                                   |
| [`64ba62a9`](https://github.com/NixOS/nixpkgs/commit/64ba62a9b67a8d72ee625191188cccc3c970e675) | `` python3Packages.mypy-boto3-transfer: 1.42.45 -> 1.42.84 ``                             |
| [`32916ddc`](https://github.com/NixOS/nixpkgs/commit/32916ddcd41fe48552f853eb2fa33ef361df21cb) | `` python3Packages.mypy-boto3-s3: 1.42.80 -> 1.42.85 ``                                   |
| [`e7d5a765`](https://github.com/NixOS/nixpkgs/commit/e7d5a765dec7fd1d4b99928328b6efbfb804757c) | `` python3Packages.mypy-boto3-outposts: 1.42.3 -> 1.42.85 ``                              |
| [`b7482d5e`](https://github.com/NixOS/nixpkgs/commit/b7482d5e75ab0047feaf7f17392d2d16e3fe28c3) | `` python3Packages.mypy-boto3-mediatailor: 1.42.55 -> 1.42.84 ``                          |
| [`ca4dff3c`](https://github.com/NixOS/nixpkgs/commit/ca4dff3c6f45fad85ebabf3bfbc58c824c23dbb0) | `` python3Packages.mypy-boto3-lightsail: 1.42.83 -> 1.42.84 ``                            |
| [`2c584d90`](https://github.com/NixOS/nixpkgs/commit/2c584d90bf9db938ad5c72ab1a65084e351dab8d) | `` python3Packages.mypy-boto3-lambda: 1.42.37 -> 1.42.85 ``                               |
| [`8524e660`](https://github.com/NixOS/nixpkgs/commit/8524e6605d8097d642849b3475385fce5d6e2fd1) | `` python3Packages.mypy-boto3-guardduty: 1.42.62 -> 1.42.84 ``                            |
| [`cd42882e`](https://github.com/NixOS/nixpkgs/commit/cd42882e543ba1afad1b2fd9683ab446b557f487) | `` python3Packages.mypy-boto3-eks: 1.42.66 -> 1.42.85 ``                                  |
| [`4c9992bb`](https://github.com/NixOS/nixpkgs/commit/4c9992bb070dfc7fae067a4ab371b3791c6d83d6) | `` python3Packages.mypy-boto3-ecs: 1.42.81 -> 1.42.85 ``                                  |
| [`acf82c60`](https://github.com/NixOS/nixpkgs/commit/acf82c603df4fdee291856c1ec974475d34dbb34) | `` python3Packages.mypy-boto3-ec2: 1.42.80 -> 1.42.85 ``                                  |
| [`07c92498`](https://github.com/NixOS/nixpkgs/commit/07c924980bb3fae0ff4538f1009509f5f4b996b8) | `` python3Packages.mypy-boto3-dlm: 1.42.3 -> 1.42.84 ``                                   |
| [`5690f60f`](https://github.com/NixOS/nixpkgs/commit/5690f60f344348e5b5505e07bb3cd29fb0c33844) | `` python3Packages.mypy-boto3-datasync: 1.42.67 -> 1.42.85 ``                             |
| [`531a09ce`](https://github.com/NixOS/nixpkgs/commit/531a09ce095153cead3580339db0fef050f7aec4) | `` python3Packages.mypy-boto3-connect: 1.42.82 -> 1.42.85 ``                              |
| [`4ffdaf3a`](https://github.com/NixOS/nixpkgs/commit/4ffdaf3a1632a873ef61d5c75d17f02896b29b34) | `` python3Packages.mypy-boto3-braket: 1.42.3 -> 1.42.85 ``                                |
| [`854eaa96`](https://github.com/NixOS/nixpkgs/commit/854eaa961a1f48c2d8e9a0cb898e28e8710b7ee8) | `` python3Packages.mypy-boto3-accessanalyzer: 1.42.3 -> 1.42.85 ``                        |
| [`b97e8b4e`](https://github.com/NixOS/nixpkgs/commit/b97e8b4e88e9d8bcad06c447f0d352e59014392d) | `` pscale: 0.277.0 -> 0.281.0 ``                                                          |
| [`0eab01e7`](https://github.com/NixOS/nixpkgs/commit/0eab01e739aeba5111d092c39f26dcfd747a8697) | `` myks: 5.11.0 -> 5.12.0 ``                                                              |
| [`377ba6e4`](https://github.com/NixOS/nixpkgs/commit/377ba6e4cf7a72d9677178667e274c415b5e452a) | `` xmrig-mo: 6.26.0-mo1 -> 6.26.0-mo2 ``                                                  |
| [`efbaa296`](https://github.com/NixOS/nixpkgs/commit/efbaa29639d7fbce89863b075ad5d3e6c7b29bcb) | `` calibre-web: orphan ``                                                                 |
| [`a50ef983`](https://github.com/NixOS/nixpkgs/commit/a50ef9831299ba843179b4090e9824cf32452275) | `` python3Packages.azure-kusto-data: 6.0.2 -> 6.0.3 ``                                    |
| [`24c6ca86`](https://github.com/NixOS/nixpkgs/commit/24c6ca86187114ffbb9ccc1327b0592fb48ccdf7) | `` odoo18: switch to pypdf ``                                                             |
| [`cdad3f52`](https://github.com/NixOS/nixpkgs/commit/cdad3f52c53f7df0cee352550cf4ac8cbda0f9db) | `` snazy: 0.58.1 -> 0.59.0 ``                                                             |
| [`821d2d03`](https://github.com/NixOS/nixpkgs/commit/821d2d033dbec111fa32921ca6a24f58e510f330) | `` snip: 0.8.1 -> 0.9.0 ``                                                                |
| [`c3a76586`](https://github.com/NixOS/nixpkgs/commit/c3a76586747d253eb984bb8e559cce7d4b544aa4) | `` rush-parallel: 0.8.0 -> 0.9.0 ``                                                       |
| [`8d012e30`](https://github.com/NixOS/nixpkgs/commit/8d012e30b6a570a6be36867f0f8a0377414435af) | `` ocamlPackages.linol: 0.10 -> 0.11 ``                                                   |
| [`8a989d94`](https://github.com/NixOS/nixpkgs/commit/8a989d94ee5133114cc117361d5130bbe660f3cc) | `` snipe-it: 8.4.0 -> 8.4.1 ``                                                            |
| [`90ac15a3`](https://github.com/NixOS/nixpkgs/commit/90ac15a3f9f550157ac67ec8777fe8e43cf7a306) | `` phel: 0.30.0 -> 0.31.0 ``                                                              |
| [`b61d633d`](https://github.com/NixOS/nixpkgs/commit/b61d633d070fae26bd3aebb7e4ffe388f47384d6) | `` ft2-clone: 2.13 -> 2.14 ``                                                             |
| [`0fffcbb0`](https://github.com/NixOS/nixpkgs/commit/0fffcbb0b0e036b2879776cb532ec6cd0f168625) | `` btop: Fix static build ``                                                              |
| [`5d51f94e`](https://github.com/NixOS/nixpkgs/commit/5d51f94e76823076a005793fbcb9d0dbbd936942) | `` json-fortran: 9.2.1 -> 9.3.0 ``                                                        |
| [`36189f93`](https://github.com/NixOS/nixpkgs/commit/36189f936ac527e6806b4de907b97ec19e721b5a) | `` python3Packages.peft: cleanup, fix on aarch64-linux ``                                 |
| [`a847e6cd`](https://github.com/NixOS/nixpkgs/commit/a847e6cda9a3fb0ef9a19648d9b699d123038012) | `` mochi: 1.21.3 -> 1.21.4 ``                                                             |
| [`bf785734`](https://github.com/NixOS/nixpkgs/commit/bf785734fb7ee6b515c03422a35ab4551ce1d825) | `` dnsdist: 2.0.2 -> 2.0.3 ``                                                             |
| [`c9f4e568`](https://github.com/NixOS/nixpkgs/commit/c9f4e568fceecda214bb5fcce67ae656d918ee6f) | `` pocket-casts: 0.12.0 -> 0.12.1 ``                                                      |
| [`bb8b3fa5`](https://github.com/NixOS/nixpkgs/commit/bb8b3fa5f27b88662b2535348864c9edd45bdefc) | `` python3Packages.mmengine: add missing test dependency, skip failing tests ``           |
| [`c2494cf6`](https://github.com/NixOS/nixpkgs/commit/c2494cf63e82d3489ad759dc58887ebf1f1e2224) | `` cel-go: 0.27.0 -> 0.28.0 ``                                                            |
| [`56324945`](https://github.com/NixOS/nixpkgs/commit/563249454d0a45ece81fb78a2f6f73ea4f7b206b) | `` ocamlPackages.lwt_eio: 0.5.1 → 0.6 ``                                                  |
| [`c310af84`](https://github.com/NixOS/nixpkgs/commit/c310af8437cb6db0561ee39ea0f48e8f9f69e5dc) | `` vivid: 0.10.1 -> 0.11.0 ``                                                             |
| [`beaa7bc1`](https://github.com/NixOS/nixpkgs/commit/beaa7bc1f579a2d1676279328ae527f075a392e0) | `` sentry-native: 0.13.4 -> 0.13.5 ``                                                     |
| [`a0addf6a`](https://github.com/NixOS/nixpkgs/commit/a0addf6a27787d3761b31dcb624a8f8d7b605c9d) | `` home-assistant-custom-components.battery_notes: 3.4.0 -> 3.4.1 ``                      |
| [`0fcfe80b`](https://github.com/NixOS/nixpkgs/commit/0fcfe80b0baf26911192f9c00bcd349da2b4a171) | `` python3Packages.webrtc-noise-gain: fix build ``                                        |
| [`1f06548f`](https://github.com/NixOS/nixpkgs/commit/1f06548f29dc09044b01543c38ac22f699479db5) | `` vals: 0.43.7 -> 0.43.8 ``                                                              |
| [`088ff131`](https://github.com/NixOS/nixpkgs/commit/088ff1312fd3ecffc09980e11bd9056ec8a41f98) | `` helmfile: 1.4.3 -> 1.4.4 ``                                                            |
| [`4fd73585`](https://github.com/NixOS/nixpkgs/commit/4fd73585bebb614a6be5043e3687fe469f67c35a) | `` grpc-health-probe: 0.4.47 -> 0.4.48 ``                                                 |
| [`3c08410c`](https://github.com/NixOS/nixpkgs/commit/3c08410ce103c55982d5a08d69a84e67a2d36e70) | `` python3Packages.pydantic-ai-slim: 1.75.0 -> 1.77.0 ``                                  |
| [`da4b8c43`](https://github.com/NixOS/nixpkgs/commit/da4b8c432271ee4c842b57efbe518f234b9ef068) | `` python3Packages.pydantic-graph: 1.75.0 -> 1.77.0 ``                                    |
| [`b85c24db`](https://github.com/NixOS/nixpkgs/commit/b85c24dbc66f88cb536708e3deebf7009c8e0a8f) | `` immich: update geodata 20250818205425 -> 20260408011516 ``                             |
| [`517e574a`](https://github.com/NixOS/nixpkgs/commit/517e574a6e606a2731f8d2a7a5ed2eaff0c1c682) | `` brltty: 6.9 -> 6.9.1 ``                                                                |
| [`67c6c471`](https://github.com/NixOS/nixpkgs/commit/67c6c471d7dc5c6bad0c7145818d72e92f656719) | `` python3Packages.signalrcore: clean up meta ``                                          |
| [`ebdb5521`](https://github.com/NixOS/nixpkgs/commit/ebdb55213c41f76c4cda3337abf412681cd82ead) | `` immich: 2.6.3 -> 2.7.2 ``                                                              |
| [`eb4e453a`](https://github.com/NixOS/nixpkgs/commit/eb4e453a245868a43b6416aeb43e6952c4bab092) | `` kdePackages.klevernotes: 1.2.5 -> 1.3.0 ``                                             |
| [`b0ae5a67`](https://github.com/NixOS/nixpkgs/commit/b0ae5a671eb0d14a288fde12137fc70a823397be) | `` nixos/gdm: add extraPackages to extend XDG_DATA_DIRS ``                                |
| [`29100ff7`](https://github.com/NixOS/nixpkgs/commit/29100ff7b1e822d198d8577a144d505306c79d61) | `` python3Packages.signalrcore: init at 1.0.2 ``                                          |
| [`cfe2f3b4`](https://github.com/NixOS/nixpkgs/commit/cfe2f3b4672edf4e81193c8de1a3d2d97644b38c) | `` gephgui-wry: 5.4.1 -> 5.5.0 ``                                                         |
| [`3c03aded`](https://github.com/NixOS/nixpkgs/commit/3c03adedfb19bbe1e911dd20086c54f41f24ad69) | `` python3Packages.cupy: drop dependency on cudnn ``                                      |
| [`d8b310de`](https://github.com/NixOS/nixpkgs/commit/d8b310de38db43696a48c32d069aa15bbd2bf335) | `` flatpak: 1.16.3 -> 1.16.4 ``                                                           |
| [`e8446224`](https://github.com/NixOS/nixpkgs/commit/e8446224d416527d69ce11acd69891807130343f) | `` eigenmath: 340-unstable-2025-05-05 -> 350 ``                                           |
| [`76736568`](https://github.com/NixOS/nixpkgs/commit/767365688ce6f97281a33a179ea855a052aa5d33) | `` cliflux: 1.9.0 -> 1.9.1 ``                                                             |
| [`5ac5ee74`](https://github.com/NixOS/nixpkgs/commit/5ac5ee74f25bd0c53f79489312b10d0c91d7fb05) | `` vgmtools: 0.1-unstable-2026-03-08 -> 0.1-unstable-2026-04-02 ``                        |
| [`3dc6f264`](https://github.com/NixOS/nixpkgs/commit/3dc6f26495e726720e79ec5a7ed17da33f70f7c7) | `` google-chrome: 146.0.7680.177 -> 147.0.7727.55 ``                                      |
| [`15b465a7`](https://github.com/NixOS/nixpkgs/commit/15b465a7b82e5aa15e07088880553f3ec8a13c40) | `` codebuff: 1.0.635 -> 1.0.638 ``                                                        |
| [`d68e7f75`](https://github.com/NixOS/nixpkgs/commit/d68e7f7567185426938d61290130e16bde68d6a7) | `` terraform-providers.baidubce_baiducloud: 1.22.21 -> 1.22.22 ``                         |
| [`2158f0b8`](https://github.com/NixOS/nixpkgs/commit/2158f0b83731d835a05cdda5c9eca145cbeb7a62) | `` renode-dts2repl: 0-unstable-2026-03-30 -> 0-unstable-2026-03-31 ``                     |
| [`f682f8d8`](https://github.com/NixOS/nixpkgs/commit/f682f8d8e6f2d8c2d2f9c2f1d2b95ba61dd49202) | `` phrase-cli: 2.57.0 -> 2.58.0 ``                                                        |
| [`3ec9ac83`](https://github.com/NixOS/nixpkgs/commit/3ec9ac831c5cf73bd00e80f43a7386deccba0e9e) | `` lux-cli: 0.26.4 -> 0.27.0 ``                                                           |
| [`3f8feba9`](https://github.com/NixOS/nixpkgs/commit/3f8feba9c37b4aa9a8234bf9e07cc3aba57678e5) | `` python3Packages.iamdata: 0.1.202604061 -> 0.1.202604071 ``                             |
| [`a74b2903`](https://github.com/NixOS/nixpkgs/commit/a74b290313a618ba212a3f27e1bcfc786a105cbc) | `` aardvark-dns: 1.17.0 -> 1.17.1 ``                                                      |
| [`80380119`](https://github.com/NixOS/nixpkgs/commit/803801194737ff7494e7aee70c318e688a970609) | `` panache: 2.29.0 -> 2.31.0 ``                                                           |
| [`d2595ed9`](https://github.com/NixOS/nixpkgs/commit/d2595ed93649411087fdeee8dc111f5c555ad944) | `` dapr-cli: 1.17.0 -> 1.17.1 ``                                                          |
| [`0def05f3`](https://github.com/NixOS/nixpkgs/commit/0def05f317e00af9dea29e3bbf80abeda415d0cc) | `` cpp-utilities: 5.33.0 -> 5.34.0 ``                                                     |
| [`7c29d99c`](https://github.com/NixOS/nixpkgs/commit/7c29d99cd3d9c8ef23136a984a178ed96e4efd52) | `` tsgolint: 0.19.0 -> 0.20.0 ``                                                          |
| [`868cd1e6`](https://github.com/NixOS/nixpkgs/commit/868cd1e6dd8d35f44095d640ff175566d6330401) | `` dcrwallet: 2.1.3 -> 2.1.4 ``                                                           |
| [`44462d46`](https://github.com/NixOS/nixpkgs/commit/44462d466c83b811249b8c8d8ee16a968c0a0955) | `` goreleaser: 2.15.0 -> 2.15.2 ``                                                        |
| [`91bf39a7`](https://github.com/NixOS/nixpkgs/commit/91bf39a711e4c5e1b878bf933fc672c5fa10b85f) | `` libretro.flycast: 0-unstable-2026-03-20 -> 0-unstable-2026-04-07 ``                    |
| [`d22a1823`](https://github.com/NixOS/nixpkgs/commit/d22a182395ccfc06d84b1b13a6ea660b0aeddb47) | `` nixVersions.git: 2026-03-28 -> 2026-04-07 ``                                           |
| [`36341693`](https://github.com/NixOS/nixpkgs/commit/36341693fab5ac961292c88cc4d8a03166ccc19a) | `` nixVersions.nix_2_28: 2.28.5 -> 2.28.6 ``                                              |
| [`cc8d42cd`](https://github.com/NixOS/nixpkgs/commit/cc8d42cd8132b12a6484f5add58471480e59d3d0) | `` nix: update nix-fallback-paths to 2.31.4 ``                                            |
| [`123da379`](https://github.com/NixOS/nixpkgs/commit/123da37985273eed01b34db436538c45e05c5cbd) | `` nixVersions.nix_2_34: 2.34.4 -> 2.34.5 ``                                              |
| [`83250692`](https://github.com/NixOS/nixpkgs/commit/83250692a8ffc491590b6f490137d12db1c77853) | `` nixVersions.nix_2_31: 2.31.3 -> 2.31.4 ``                                              |
| [`b368ccee`](https://github.com/NixOS/nixpkgs/commit/b368cceed7f6ff4aa8154507da051055e886132b) | `` nixVersions.nix_2_30: 2.30.3 -> 2.30.4 ``                                              |
| [`bd949278`](https://github.com/NixOS/nixpkgs/commit/bd94927823d0c63feb6b22f22b259269bece340f) | `` uxplay: 1.73.5 -> 1.73.6 ``                                                            |
| [`3c35ad0f`](https://github.com/NixOS/nixpkgs/commit/3c35ad0f9f211f787bab919f72192e6629bbcc0f) | `` matrix-synapse-unwrapped: 1.150.0 -> 1.151.0 ``                                        |
| [`7e3dc26f`](https://github.com/NixOS/nixpkgs/commit/7e3dc26feb3e69499ecc23d4283d2ad863af4dae) | `` python3Packages.llm-gemini: 0.29 -> 0.30 ``                                            |
| [`0531ad87`](https://github.com/NixOS/nixpkgs/commit/0531ad87aef5ca083d3617cb5aaf3894834d64a0) | `` treefmt: 2.4.1 -> 2.5.0 ``                                                             |
| [`d620f0db`](https://github.com/NixOS/nixpkgs/commit/d620f0dbadafe91c45140701cb41f1d51080f74c) | `` kdePackages.qtutilities: 6.20.0 -> 6.21.0 ``                                           |
| [`23117eed`](https://github.com/NixOS/nixpkgs/commit/23117eed7884ebc2dee86742ce74eb59878710ea) | `` openvino: 2026.0.0 -> 2026.1.0 ``                                                      |
| [`b8866890`](https://github.com/NixOS/nixpkgs/commit/b8866890e5b985a74a9471b317367dd79a897cb6) | `` retroshare: require CMake 3.10 in supportlibs ``                                       |
| [`2bf39f7b`](https://github.com/NixOS/nixpkgs/commit/2bf39f7b5ab7b836242a800dfc1cfd5814baf1cb) | `` ocamlPackages.httpcats: 0.2.0 → 0.2.1 ``                                               |
| [`f40898fc`](https://github.com/NixOS/nixpkgs/commit/f40898fc9ecd3f6d7c04a09620c470e2f268f6bc) | `` victorialogs: 1.48.0 -> 1.49.0 ``                                                      |
| [`5e90295f`](https://github.com/NixOS/nixpkgs/commit/5e90295f4ed320e32fb1f28904fcd12ab0b63cac) | `` govee2mqtt: add maintainer niklaskorz ``                                               |
| [`98f4613e`](https://github.com/NixOS/nixpkgs/commit/98f4613e30a9d24c0c6c1cef01d2b36192a234c0) | `` govee2mqtt: 2025.11.25-60a39bcc -> 2026.03.25-ab9deb66 ``                              |
| [`454ed60c`](https://github.com/NixOS/nixpkgs/commit/454ed60cf45d8190bf54ea6237d7987b72a10d9b) | `` vscode-extensions.ms-azuretools.vscode-bicep: 0.41.2 -> 0.42.1 ``                      |
| [`b563c5b2`](https://github.com/NixOS/nixpkgs/commit/b563c5b211ba2dc4cd78b5e2ea7587ad294e52e4) | `` glamoroustoolkit: 1.1.47 -> 1.1.58 ``                                                  |
| [`2db45a5d`](https://github.com/NixOS/nixpkgs/commit/2db45a5d93e12a4ec9a8cd8d75c3bd69275d90d3) | `` python3Packages.textual: 8.2.1 -> 8.2.3 ``                                             |
| [`545dd30e`](https://github.com/NixOS/nixpkgs/commit/545dd30e9facee2acbc4507795dab2ea5407ff47) | `` libretro.bsnes: 0-unstable-2026-01-16 -> 0-unstable-2026-03-31 ``                      |
| [`84133f7f`](https://github.com/NixOS/nixpkgs/commit/84133f7f69f9621d102a83fdb933ac9d76bf10cb) | `` python3Packages.hole: migrate to finalAttrs ``                                         |
| [`4ee1cb72`](https://github.com/NixOS/nixpkgs/commit/4ee1cb72377bcb5ca892d5f2483b4a10cf0814ac) | `` python3Packages.hole: 0.9.0 -> 0.9.1 ``                                                |
| [`14c100ff`](https://github.com/NixOS/nixpkgs/commit/14c100ffb498d7dfe082d4fd6bce7bc1e1e258cf) | `` nixosTests.armagetronad: use virtio-gpu for client VMs ``                              |
| [`a5019cfe`](https://github.com/NixOS/nixpkgs/commit/a5019cfe33187bfab2ab8ea281fb4c3ab650cdec) | `` me3: use effective install permissions ``                                              |
| [`50eec35e`](https://github.com/NixOS/nixpkgs/commit/50eec35e48a03435730b68b851bd27213ea1c802) | `` nixComponents_git: add patches for GHSA-g3g9-5vj6-r3gj ``                              |
| [`7ca89c4a`](https://github.com/NixOS/nixpkgs/commit/7ca89c4ab60606c7ecdb10c57ef91553f31c10a5) | `` nixComponents_2_34: add patches for GHSA-g3g9-5vj6-r3gj ``                             |
| [`be231299`](https://github.com/NixOS/nixpkgs/commit/be231299383aa4a41ed83ee422f07f316f0fa63c) | `` nixComponents_2_31: add patches for GHSA-g3g9-5vj6-r3gj ``                             |
| [`0559d6b9`](https://github.com/NixOS/nixpkgs/commit/0559d6b958f331de3ef86e35141bc06b22d94bbd) | `` python3Packages.libdebug: init at 0.9.0 ``                                             |
| [`9c32386c`](https://github.com/NixOS/nixpkgs/commit/9c32386c278f4d0028caf839506892780400014f) | `` nixos/journald: move enableHttpGateway rename to journald-gateway.nix ``               |
| [`f1bf13d0`](https://github.com/NixOS/nixpkgs/commit/f1bf13d0a4b72131f70da04fd8d085696c68d02c) | `` nixos/stage-1,swraid: move mdadmConf rename to swraid.nix ``                           |
| [`69e8fef8`](https://github.com/NixOS/nixpkgs/commit/69e8fef8129d2a7377f212f8fbd0a1ceb1f38ca3) | `` nixComponents_2_30: add patch for GHSA-g3g9-5vj6-r3gj ``                               |
| [`128dad70`](https://github.com/NixOS/nixpkgs/commit/128dad70c66d00c248c9821fc3e45222818a0e3f) | `` nix_2_28: add patch for GHSA-g3g9-5vj6-r3gj ``                                         |
| [`7ff7e9fd`](https://github.com/NixOS/nixpkgs/commit/7ff7e9fd797626a6d597fd1f5b88145330ffe676) | `` ketesa: 0.11.4-etke54 -> 1.1.0 ``                                                      |
| [`3cfa1bbc`](https://github.com/NixOS/nixpkgs/commit/3cfa1bbc0fb779b609f3c2eb59088793e5f03d88) | `` libretro.atari800: 0-unstable-2026-01-30 -> 0-unstable-2026-03-31 ``                   |
| [`8cb3a579`](https://github.com/NixOS/nixpkgs/commit/8cb3a579fbab22f8d2edda056de1b5db4a262fa6) | `` pleroma: update to OTP 27 and elixir 1.18 ``                                           |
| [`7dd8afb2`](https://github.com/NixOS/nixpkgs/commit/7dd8afb21d19b4994cdc2c80020f8a4cdd99ded4) | `` terraform-providers.hashicorp_google: 7.25.0 -> 7.26.0 ``                              |
| [`5950c9de`](https://github.com/NixOS/nixpkgs/commit/5950c9de6adf8fe0fce32e9dcb41bdd7b9b9b0a2) | `` python3Packages.django_6: 6.0.3 -> 6.0.4 ``                                            |
| [`84d742bb`](https://github.com/NixOS/nixpkgs/commit/84d742bba87bebba71d5fe0a50bec4071ad635ec) | `` openfreebuds: 0.17.1 -> 0.17.3 ``                                                      |
| [`9515671d`](https://github.com/NixOS/nixpkgs/commit/9515671ddd2171c9e1a5e6db4a4a4d6ea3261118) | `` python3Packages.tessie-api: 0.1.2 -> 0.1.3 ``                                          |
| [`7954f69f`](https://github.com/NixOS/nixpkgs/commit/7954f69fd07074ef1d20af6434d3bebf244d21df) | `` erlang_28: 28.4.1 -> 28.4.2 ``                                                         |
| [`74fdecfb`](https://github.com/NixOS/nixpkgs/commit/74fdecfbe44d92f21770f36ba6fadc2ce01f84b3) | `` erlang_27: 27.3.4.9 -> 27.3.4.10 ``                                                    |
| [`d4bc492c`](https://github.com/NixOS/nixpkgs/commit/d4bc492cb1aa00c6c0c698d91a6db1589cd8c9a5) | `` vscode-extensions.github.codespaces: 1.18.11 -> 1.18.12 ``                             |
| [`f5942ae4`](https://github.com/NixOS/nixpkgs/commit/f5942ae4a81ffc831543a9261b8f6029d80c2668) | `` redact: fix passthru.updateScript ``                                                   |
| [`cc49931e`](https://github.com/NixOS/nixpkgs/commit/cc49931e1674f5d98d1be6c6de97ec23d73055a3) | `` redact: 0.18.0 -> 0.21.18 ``                                                           |
| [`1283f2ac`](https://github.com/NixOS/nixpkgs/commit/1283f2ac3f810928e1abc8af746a47f365443cbe) | `` forgejo-runner: 12.7.3 -> 12.8.2 ``                                                    |
| [`3de646d9`](https://github.com/NixOS/nixpkgs/commit/3de646d9e01af7e34750b847b56225bcfa4edd95) | `` python3Packages.cloup: 3.0.8 -> 3.0.9 ``                                               |
| [`422503a6`](https://github.com/NixOS/nixpkgs/commit/422503a67b7c8048568afc89fca6f72a2eb02523) | `` armagetronad: fix build failure for armagetronad."0.4" ``                              |
| [`3472429f`](https://github.com/NixOS/nixpkgs/commit/3472429f215d1d05cd411ba896313d8a3b993092) | `` esphome: 2026.3.2 -> 2026.3.3 ``                                                       |
| [`0e8ed6fc`](https://github.com/NixOS/nixpkgs/commit/0e8ed6fc0c7b66d06fcee544c1f68007f3a306a7) | `` feishin: 1.10.0 -> 1.11.0 ``                                                           |
| [`591d34a3`](https://github.com/NixOS/nixpkgs/commit/591d34a3a7209e12519209895991f89f4a6cbc67) | `` libretro.fuse: 0-unstable-2024-11-24 -> 0-unstable-2026-03-31 ``                       |
| [`029e37dd`](https://github.com/NixOS/nixpkgs/commit/029e37dd191883fc0a77e6a4943fe679bb174c07) | `` mark: 16.0.2 -> 16.2.0 ``                                                              |
| [`02ce591d`](https://github.com/NixOS/nixpkgs/commit/02ce591d4ba7c3ccc665dacf4d70b20b6506085f) | `` kdePackages: Plasma 6.6.3 -> 6.6.4 ``                                                  |
| [`e3183e23`](https://github.com/NixOS/nixpkgs/commit/e3183e23e7f241686c0ce98740045216700c5868) | `` tango-cpp: add meta.changelog ``                                                       |
| [`66c2a56c`](https://github.com/NixOS/nixpkgs/commit/66c2a56cb872313ccf94fbb1a7b968653afc0a76) | `` osu-lazer: 2026.401.0 -> 2026.406.0 ``                                                 |
| [`ae5450a4`](https://github.com/NixOS/nixpkgs/commit/ae5450a449b10cb218ab08e442d0989f0d780ff5) | `` osu-lazer-bin: 2026.401.0 -> 2026.406.0 ``                                             |
| [`256cdc7c`](https://github.com/NixOS/nixpkgs/commit/256cdc7c521f014f2ad28a708d7a646cc608fcc8) | `` retroshare: fix build ``                                                               |
| [`28e0df47`](https://github.com/NixOS/nixpkgs/commit/28e0df470e7bd1adac1be3e1d40334a0789312e7) | `` terraform-providers.equinix_equinix: 4.13.0 -> 4.15.0 ``                               |
| [`3ed44449`](https://github.com/NixOS/nixpkgs/commit/3ed44449a3cf97d40a3ca5cc095c5d348740d9af) | `` python3Packages.pymc: 5.28.3 -> 5.28.4 ``                                              |
| [`f02b94ea`](https://github.com/NixOS/nixpkgs/commit/f02b94ea624326cfb1c077268df791eac2bd6908) | `` python3Packages.pyannote-audio: 4.0.3 -> 4.0.4 ``                                      |
| [`91b75745`](https://github.com/NixOS/nixpkgs/commit/91b757451249afac721ab57ca8e9b1d015ba9bec) | `` watchexec: 2.5.0 -> 2.5.1 ``                                                           |
| [`d937969e`](https://github.com/NixOS/nixpkgs/commit/d937969ee65d55318678a5a1f379ff388b028098) | `` webcord: 4.12.1 -> 4.13.0 ``                                                           |
| [`457ebc3d`](https://github.com/NixOS/nixpkgs/commit/457ebc3de4606e9e7009444227811de51ac4715b) | `` railway: 4.35.0 -> 4.36.1 ``                                                           |
| [`938c8955`](https://github.com/NixOS/nixpkgs/commit/938c895553e279ccb197c3568052891c2d9c1bec) | `` kubectl-gadget: 0.50.1 -> 0.51.0 ``                                                    |
| [`5d3a836e`](https://github.com/NixOS/nixpkgs/commit/5d3a836e9849f6a57a54fe5d957d5746bd4d57dc) | `` zellij: 0.44.0 -> 0.44.1 ``                                                            |
| [`c02cfe21`](https://github.com/NixOS/nixpkgs/commit/c02cfe212c24ca37f644cb6580e88d4283094fe4) | `` neovim[-unwrapped]: 0.12.0 -> 0.12.1 ``                                                |
| [`00b34cfd`](https://github.com/NixOS/nixpkgs/commit/00b34cfd1534f5e0d19d58a13a7f764854d34c52) | `` elixir_1_15, elixir_1_16: remove ``                                                    |
| [`5d13fc99`](https://github.com/NixOS/nixpkgs/commit/5d13fc99819478abc25b33910fded046105b680a) | `` erlang_26: remove ``                                                                   |
| [`669ad088`](https://github.com/NixOS/nixpkgs/commit/669ad0887eeb8882865fa304acb928c787518888) | `` freefilesync: 14.8 -> 14.9 ``                                                          |
| [`72cb6d9d`](https://github.com/NixOS/nixpkgs/commit/72cb6d9d1107e295fe23bc63fe6b5f581143a2ec) | `` beans: add shell completions ``                                                        |
| [`e76403f0`](https://github.com/NixOS/nixpkgs/commit/e76403f0ff18e8c2a4a35d5f72b46ea7e93f3c42) | `` nixos/kanidm: remove TemporaryFileSystem masking / ``                                  |
| [`dc3e0601`](https://github.com/NixOS/nixpkgs/commit/dc3e0601fb1c0877a425d6d15a1d38281edaf38f) | `` vimPlugins.grug-far-nvim: prevent screenshot tests from failing (2) ``                 |
| [`0e06807d`](https://github.com/NixOS/nixpkgs/commit/0e06807dbf4d51d062fbd8c73e65eec52e9007c8) | `` vacuum-go: 0.25.2 -> 0.25.5 ``                                                         |
| [`d1e1042a`](https://github.com/NixOS/nixpkgs/commit/d1e1042a1b80b856de19f4f842a4ef8642cea0b3) | `` tbls: 1.94.0 -> 1.94.2 ``                                                              |
| [`8138e69f`](https://github.com/NixOS/nixpkgs/commit/8138e69f7f379ac3c8fca11014161f09b27d5cda) | `` arnis: init at 2.6.0 ``                                                                |
| [`2fd58cf0`](https://github.com/NixOS/nixpkgs/commit/2fd58cf067634a1b70691db3145ef5edbca177d2) | `` firefox-bin-unwrapped: 149.0 -> 149.0.2 ``                                             |
| [`f2315ad3`](https://github.com/NixOS/nixpkgs/commit/f2315ad3189bd7e3445b553ab99c8ee588e6270b) | `` firefox-unwrapped: 149.0 -> 149.0.2 ``                                                 |
| [`e6102d53`](https://github.com/NixOS/nixpkgs/commit/e6102d53fd0f64cee140782ef7ac176eef761afe) | `` sub-store: 2.21.64 -> 2.21.81 ``                                                       |
| [`903f763a`](https://github.com/NixOS/nixpkgs/commit/903f763a9d1c066e1fa19cf075babf0c70ed6ab6) | `` qdmr: 0.14.0 -> 0.14.1 ``                                                              |
| [`dab1f300`](https://github.com/NixOS/nixpkgs/commit/dab1f30049d8b8bd44ec0506914a7f1e16b5f84e) | `` exploitdb: 2026-03-04 -> 2026-04-07 ``                                                 |
| [`7d4b9e18`](https://github.com/NixOS/nixpkgs/commit/7d4b9e18749c1179739525d157dc769993a23a78) | `` luaPackages.ltreesitter{,-ts}: move env variables into env for structuredAttrs ``      |
| [`8dd7cb57`](https://github.com/NixOS/nixpkgs/commit/8dd7cb573481293a95cf3420a0bf33f1e388bf40) | `` tea: 0.12.0 -> 0.13.0 ``                                                               |
| [`3fba8cd5`](https://github.com/NixOS/nixpkgs/commit/3fba8cd557f2f4ffa826edea6563e6d417ad87a5) | `` kapp: 0.65.1 -> 0.66.0 ``                                                              |
| [`aad144fc`](https://github.com/NixOS/nixpkgs/commit/aad144fce0afa1f96b7c67805a407b938f6f21f9) | `` tango-database: 5.28 -> 5.29 ``                                                        |
| [`c5455bdb`](https://github.com/NixOS/nixpkgs/commit/c5455bdb416888d9162ae8484b25fc774f6fa8d4) | `` vscode-extensions.emmanuelbeziat.vscode-great-icons: 2.1.120 -> 2.1.121 ``             |
| [`7e2d1796`](https://github.com/NixOS/nixpkgs/commit/7e2d17960739b06cdf8ef9dfb131576de5637e86) | `` nix-user-chroot: move env variable into env for structuredAttrs ``                     |
| [`53c83a03`](https://github.com/NixOS/nixpkgs/commit/53c83a0344651a1f4f8626bbea7d00301cc4bdcd) | `` python3Packages.pyfreshr: 1.2.0 -> 1.2.1 ``                                            |
| [`e50e0f95`](https://github.com/NixOS/nixpkgs/commit/e50e0f953beef5ec450018422fa568f6df68052e) | `` sub-store-frontend: 2.16.30 -> 2.16.46 ``                                              |
| [`b790ee99`](https://github.com/NixOS/nixpkgs/commit/b790ee994646dbfc99fdee38a870b70cf1d3872f) | `` oboete: 0.2.3 -> 0.2.4 ``                                                              |
| [`fbf93c36`](https://github.com/NixOS/nixpkgs/commit/fbf93c36fe5afc813c29d719c99d1568a008d9c8) | `` tcl-9_0: 9.0.1 -> 9.0.3 ``                                                             |
| [`363596cd`](https://github.com/NixOS/nixpkgs/commit/363596cd761e0308a27e9b742b7ec5b177f4fcb5) | `` python3Packages.mediawiki-langcodes: 0.2.19 -> 0.2.20 ``                               |
| [`5076fb66`](https://github.com/NixOS/nixpkgs/commit/5076fb66385a617cb8584fc153af7f188228417f) | `` python3Packages.pysmlight: 0.3.1 -> 0.3.2 ``                                           |
| [`6586980b`](https://github.com/NixOS/nixpkgs/commit/6586980bf2b9422c65c3e377b028bb90231c1457) | `` pulumi-bin: 3.228.0 -> 3.229.0 ``                                                      |
| [`6b67cba7`](https://github.com/NixOS/nixpkgs/commit/6b67cba75d7e088dc3a00493e0969178c9f38259) | `` wheelwizard: 2.4.2 -> 2.4.3 ``                                                         |
| [`75b7c82b`](https://github.com/NixOS/nixpkgs/commit/75b7c82b907a5828604d7c12afae52a96f6c2136) | `` ollama: 0.20.2 -> 0.20.3 ``                                                            |
| [`099d66d6`](https://github.com/NixOS/nixpkgs/commit/099d66d6ac37ae88e95d897cbfa2a0bed75d3ad2) | `` unstructured-api: 0.1.1 -> 0.1.2 ``                                                    |
| [`30cc1d20`](https://github.com/NixOS/nixpkgs/commit/30cc1d204bce56c438f84ad3035c2e9fa280ac81) | `` demucs-rs: init at 0.3.4 ``                                                            |
| [`b8f679a9`](https://github.com/NixOS/nixpkgs/commit/b8f679a983bf4dfc9cf46917ba3073ebf5899113) | `` rumdl: 0.1.62 -> 0.1.67 ``                                                             |
| [`127f0592`](https://github.com/NixOS/nixpkgs/commit/127f059255208c8299ce22eae8559f2a1880bb37) | `` ranger: 1.9.4-unstable-2026-02-25 -> 1.9.4-unstable-2026-04-02 ``                      |
| [`3d5c124e`](https://github.com/NixOS/nixpkgs/commit/3d5c124e6844b24fd4a9ce2035990b4be076b0c5) | `` python3Packages.volkszaehler: migrate to finalAttrs ``                                 |
| [`b1c6c6e4`](https://github.com/NixOS/nixpkgs/commit/b1c6c6e4630a49121c812a597662da1dc51c8d0f) | `` python3Packages.volkszaehler: 0.5.2 -> 0.6.0 ``                                        |
| [`b57eae8b`](https://github.com/NixOS/nixpkgs/commit/b57eae8b862d7bcec9cb636ab218812161f55ace) | `` vimPlugins.better-diagnostic-virtual-text: init at 0-unstable-2024-07-27 ``            |
| [`093fee9f`](https://github.com/NixOS/nixpkgs/commit/093fee9fd69a690608557bb58ba381de70fdcf78) | `` vimPlugins.garbage-day-nvim: init at 1.4.0-unstable-2026-02-25 ``                      |
| [`bc3ec9e1`](https://github.com/NixOS/nixpkgs/commit/bc3ec9e1d99d6a8f8c23adc4b89ac5a2281ca3b9) | `` vimPlugins.runner-nvim: init at 0-unstable-2026-02-11 ``                               |
| [`c0a1b9c4`](https://github.com/NixOS/nixpkgs/commit/c0a1b9c43bfac061a8f8b5f3be407ab16c154e38) | `` sandhole: fix Darwin builds ``                                                         |
| [`d6f52c56`](https://github.com/NixOS/nixpkgs/commit/d6f52c560c225975ccffdad6a4671791abc5729d) | `` python3Packages.sphinxcontrib-confluencebuilder: 3.0.0 -> 3.1.0 ``                     |
| [`1372584e`](https://github.com/NixOS/nixpkgs/commit/1372584ef63cd5927cd2507422cd358006df0114) | `` openttd: 15.2 -> 15.3 ``                                                               |
| [`64db88be`](https://github.com/NixOS/nixpkgs/commit/64db88befe6a7de3dc62148ec9ff4753310138c4) | `` stable-diffusion-cpp: master-537-545fac4 -> master-558-8afbeb6 ``                      |
| [`09fad59a`](https://github.com/NixOS/nixpkgs/commit/09fad59a8175260a3deed06780101b89466ef1e9) | `` process-compose: 1.94.0 -> 1.103.0 ``                                                  |
| [`78ac05d9`](https://github.com/NixOS/nixpkgs/commit/78ac05d95885e518f107ecd5d0855a654ca8febb) | `` tor-browser: 15.0.8 -> 15.0.9 ``                                                       |
| [`02f91c88`](https://github.com/NixOS/nixpkgs/commit/02f91c884a7395eb940d6107b82b0240523b9038) | `` qradiolink: 0.9.1-3 -> 0.10.2-1 ``                                                     |
| [`27919aaf`](https://github.com/NixOS/nixpkgs/commit/27919aaf231aeda76663b6ea641c704134d73022) | `` grafanaPlugins.victoriametrics-metrics-datasource: 0.23.1 -> 0.23.3 ``                 |
| [`012d0dcd`](https://github.com/NixOS/nixpkgs/commit/012d0dcd6eaaecb93935c12173d1a90a9af593ce) | `` github-runner: work around darwin testfailures by disabling sandbox ``                 |
| [`279ebe1c`](https://github.com/NixOS/nixpkgs/commit/279ebe1c7f56de58ab91352fc9a21d98b89c882e) | `` ord: 0.27.0 -> 0.27.1 ``                                                               |
| [`4aa5d59b`](https://github.com/NixOS/nixpkgs/commit/4aa5d59bc6f3c84b4d81bb1c1cbf5d36d00f6679) | `` nerdctl: add miniharinn as a maintainer ``                                             |
| [`38aa3c1f`](https://github.com/NixOS/nixpkgs/commit/38aa3c1f5db2bc926b9dc0b29c2e834aca053013) | `` nerdctl: 2.2.1 -> 2.2.2 ``                                                             |
| [`ea7c7def`](https://github.com/NixOS/nixpkgs/commit/ea7c7defe170f48e0b0e316bde7c4d0524eda292) | `` postgrest: 14.7 -> 14.8 ``                                                             |
| [`6cc12666`](https://github.com/NixOS/nixpkgs/commit/6cc12666a716980c345a57c5a1e0aeb8f3c1f265) | `` python3Packages.jupyter-collaboration-ui: 2.2.1 -> 2.3.0 ``                            |
| [`56851c4f`](https://github.com/NixOS/nixpkgs/commit/56851c4fc2989c760f3b70a7cf9d6671f917f18a) | `` markdown-code-runner: 0.3.2 -> 0.4.2 ``                                                |
| [`b0cbea68`](https://github.com/NixOS/nixpkgs/commit/b0cbea68dd5cb8bcce2a1d7ecc33c0b5239e61a9) | `` oci-cli: 3.76.0 -> 3.77.0 ``                                                           |
| [`41f07cc6`](https://github.com/NixOS/nixpkgs/commit/41f07cc6dd31afe3e1fb94e8a0181a64330783f4) | `` qsv: 18.0.0 -> 19.0.0 ``                                                               |
| [`b8cebdb9`](https://github.com/NixOS/nixpkgs/commit/b8cebdb9ff24009e11806294cc8417f4845e382f) | `` python3Packages.blackjax: skip flaky numerical tests ``                                |
| [`fe6c4d33`](https://github.com/NixOS/nixpkgs/commit/fe6c4d33780e837b4f126ff6aa4734d6c8f4d294) | `` home-assistant-custom-lovelace-modules.versatile-thermostat-ui-card: 1.1.4 -> 3.2.0 `` |
| [`0adff3bc`](https://github.com/NixOS/nixpkgs/commit/0adff3bc0ffcde189afe4cbb630e0130fa350c4a) | `` home-assistant-custom-components.smartthinq-sensors: 0.41.2 -> 0.42.0 ``               |
| [`c7abb44f`](https://github.com/NixOS/nixpkgs/commit/c7abb44f37c69bf97f1cc6b0334fd843f8004238) | `` python3Packages.redshift-connector: 2.1.12 -> 2.1.13 ``                                |
| [`20c26b05`](https://github.com/NixOS/nixpkgs/commit/20c26b0531aa6cb69a25360b369f5e222e6d7f72) | `` tektoncd-cli: 0.44.0 -> 0.44.1 ``                                                      |
| [`95930041`](https://github.com/NixOS/nixpkgs/commit/95930041941892584d5a95f82dee457bdda7db24) | `` microsoft-edge: 146.0.3856.84 -> 146.0.3856.97 ``                                      |
| [`1044c390`](https://github.com/NixOS/nixpkgs/commit/1044c3905cb88eedbd5e9e00eeb1384bc88819a8) | `` prometheus-mongodb-exporter: 0.49.0 -> 0.50.0 ``                                       |
| [`6206b54f`](https://github.com/NixOS/nixpkgs/commit/6206b54fd6b7b11676bd40260bf2ff0d9d063077) | `` python3Packages.tensorflow: add missing hash for x86_64-linux GPU ``                   |
| [`7eb0383a`](https://github.com/NixOS/nixpkgs/commit/7eb0383ade3b66cbe497262f1106324817952457) | `` moor: 2.11.1 -> 2.12.0 ``                                                              |
| [`21862a4b`](https://github.com/NixOS/nixpkgs/commit/21862a4b8cccecb55cf9a9e0a95b7ae993a1a016) | `` python3Packages.python-mystrom: migrate to finalAttrs ``                               |
| [`0b84c7a8`](https://github.com/NixOS/nixpkgs/commit/0b84c7a8ec04630554eba9dce148ea9a95f14af6) | `` python3Packages.python-mystrom: 2.6.0 -> 2.7.0 ``                                      |
| [`5e59f370`](https://github.com/NixOS/nixpkgs/commit/5e59f370c89b5a0603596a9701dd60b224954b89) | `` python3Packages.torchaudio: fix darwin build ``                                        |
| [`fa517ea0`](https://github.com/NixOS/nixpkgs/commit/fa517ea0a02a5b28b79e9b1fc3168f2e936cbcf6) | `` clouddrive2: 1.0.3 -> 1.0.4 ``                                                         |
| [`7ce2561f`](https://github.com/NixOS/nixpkgs/commit/7ce2561f430d1fda81a54d30da8c666b2baa02d0) | `` python3Packages.bk7231tools: 2.1.0 -> 2.1.2 ``                                         |
| [`2813d969`](https://github.com/NixOS/nixpkgs/commit/2813d969098c2345dea573d7817ca031975ee887) | `` vscode-extensions.illixion.vscode-vibrancy-continued: 1.1.65 -> 1.1.73 ``              |
| [`80f62dd8`](https://github.com/NixOS/nixpkgs/commit/80f62dd82ced3a26d7046318d46737aa993ddb41) | `` golden-cheetah: 3.7-SP1 -> 3.8-DEV2603 ``                                              |
| [`9941a3b9`](https://github.com/NixOS/nixpkgs/commit/9941a3b9b82aa6883f5ff0c3186fd086d5f78998) | `` zuban: 0.6.2 -> 0.7.0 ``                                                               |
| [`cffa8197`](https://github.com/NixOS/nixpkgs/commit/cffa81975f3326538c5ed2fc934eab73e812fc9a) | `` libretro.freeintv: 0-unstable-2026-02-24 -> 0-unstable-2026-03-31 ``                   |
| [`054438bc`](https://github.com/NixOS/nixpkgs/commit/054438bcb4f9522c93853ca25d3d9f5f48c5dcc8) | `` vscode-extensions.amazonwebservices.amazon-q-vscode: 1.112.0 -> 2.0.0 ``               |
| [`3ddf18ca`](https://github.com/NixOS/nixpkgs/commit/3ddf18ca4ecf35bfb54c712f3aa373f66037495a) | `` python3Packages.great-tables: cleanup, skip failing test ``                            |
| [`0a0f378f`](https://github.com/NixOS/nixpkgs/commit/0a0f378faf4c1636e0acd1492dddb37394d6bde1) | `` nqptp: 1.2.4 -> 1.2.6 ``                                                               |
| [`cc58e8a7`](https://github.com/NixOS/nixpkgs/commit/cc58e8a76da00c7ccf147c034c5bec830266ba70) | `` python3Packages.ansible-compat: 25.12.1 -> 26.3.0 ``                                   |
| [`73caf55a`](https://github.com/NixOS/nixpkgs/commit/73caf55aac347c72d03c291e752e0c2842a47df4) | `` ultralytics: 8.4.32 -> 8.4.34 ``                                                       |
| [`6f22706b`](https://github.com/NixOS/nixpkgs/commit/6f22706bbee6425db0ed696108420bfb655cfb92) | `` libretro.beetle-psx: 0-unstable-2026-03-28 -> 0-unstable-2026-04-03 ``                 |
| [`9fedf3ec`](https://github.com/NixOS/nixpkgs/commit/9fedf3ecd536cf9a8cf84271b29c55aaffbacba8) | `` python3Packages.langchain-ollama: 1.0.1 -> 1.1.0 ``                                    |
| [`6851838f`](https://github.com/NixOS/nixpkgs/commit/6851838fa5c7a2b356aa9b072250dd60627f511b) | `` baresip: 4.6.0 -> 4.7.0 ``                                                             |
| [`d0bf37f8`](https://github.com/NixOS/nixpkgs/commit/d0bf37f854fc191142f92d006e81651cc485eb53) | `` amass: 5.0.1 -> 5.1.1 ``                                                               |
| [`0b80f2be`](https://github.com/NixOS/nixpkgs/commit/0b80f2be8b87d21f51ea6df9d9fb81a0774836a2) | `` terraform-providers.maxlaverse_bitwarden: 0.17.3 -> 0.17.6 ``                          |
| [`ae91e725`](https://github.com/NixOS/nixpkgs/commit/ae91e725788b6230822bb3982870aa8f16955df6) | `` ibtool: 1.1.3 -> 1.1.4 ``                                                              |
| [`60942576`](https://github.com/NixOS/nixpkgs/commit/60942576e7e17fc8160a261bafe1971f6f43793a) | `` python3Packages.victron-mqtt: 2026.3.12 -> 2026.4.1 ``                                 |
| [`a6686baa`](https://github.com/NixOS/nixpkgs/commit/a6686baa7a803b73ae21cfa71d3324f7016c942f) | `` vscode-extensions.ryu1kn.partial-diff: 1.4.4 -> 1.4.6 ``                               |
| [`89ea8d78`](https://github.com/NixOS/nixpkgs/commit/89ea8d7829e4e5f5724781e3f02b9cd31ee0a8b2) | `` python3Packages.stanza: 1.11.0 -> 1.11.1 ``                                            |
| [`96f650fa`](https://github.com/NixOS/nixpkgs/commit/96f650fa624349b307a919bc99191cb6aeea64a2) | `` python3Packages.udtools: init at 0.2.7 ``                                              |
| [`26c079a2`](https://github.com/NixOS/nixpkgs/commit/26c079a21eaad5f892fd4051da060b8f8c0da3c4) | `` bitwig-studio: bitwig-studio5 -> bitwig-studio6 ``                                     |
| [`655e3354`](https://github.com/NixOS/nixpkgs/commit/655e3354167d63919a7f376897aa762d45d595e9) | `` bitwig-studio6: init at 6.0 ``                                                         |
| [`e3b21a73`](https://github.com/NixOS/nixpkgs/commit/e3b21a7341d6491b98319a3798ca99d61f07f55c) | `` python3Packages.peakrdl-cheader: 1.0.0 -> 1.1.0 ``                                     |
| [`e3505dd5`](https://github.com/NixOS/nixpkgs/commit/e3505dd5c6d217188c0d9bee3d2f3eaa2cfd85bc) | `` terraform-providers.oracle_oci: 8.7.0 -> 8.8.0 ``                                      |
| [`8de50767`](https://github.com/NixOS/nixpkgs/commit/8de507677bc1ce8b883af5907a93aa89b292540e) | `` python3Packages.peakrdl-cheader: use finalAttrs style ``                               |
| [`cb93db89`](https://github.com/NixOS/nixpkgs/commit/cb93db89285547e01acc44341a623b00d91ff0b6) | `` tideways-cli: 1.2.14 -> 1.2.16 ``                                                      |

*... and 2013 more commits (truncated)*