### PR TITLE
chore(flake/nixpkgs): `d2339023` -> `29916453`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779508470,
+        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "29916453413845e54a65b8a1cf996842300cd299",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`9c47d312`](https://github.com/NixOS/nixpkgs/commit/9c47d3127c7a49202063e6094191e832aa5db074) | `` python3Packages.agentic-threat-hunting-framework: 0.12.0 -> 0.13.0 ``                      |
| [`a00f79b5`](https://github.com/NixOS/nixpkgs/commit/a00f79b5e701ac5a683f0b519660ff56be3ea82b) | `` exploitdb: 2026-05-16 -> 2026-05-22 ``                                                     |
| [`09be9bde`](https://github.com/NixOS/nixpkgs/commit/09be9bde87024f43fc893c4f0a2f6a5a8f16fa7d) | `` python3Pakcages.aiocsv: modernize ``                                                       |
| [`14d693c1`](https://github.com/NixOS/nixpkgs/commit/14d693c140c7051cbdd2dc60d193b37d46e2759c) | `` sahel-fonts: add pancaek as maintainer ``                                                  |
| [`13cbb0c1`](https://github.com/NixOS/nixpkgs/commit/13cbb0c1c0e5723fb0c75e00acd8ae5357542c34) | `` sahel-fonts: use installFonts ``                                                           |
| [`660f9a8e`](https://github.com/NixOS/nixpkgs/commit/660f9a8edf07049eeeae99406ff252f784aebac0) | `` python3Packages.garminconnect: migrate to finalAttrs ``                                    |
| [`9cd4feed`](https://github.com/NixOS/nixpkgs/commit/9cd4feedd5fc5953751377a26cba8ddc54b7913e) | `` fragment-mono: use installFonts ``                                                         |
| [`c88cfc38`](https://github.com/NixOS/nixpkgs/commit/c88cfc3862b25647e64c667f538e8e067687e583) | `` python3Packages.aiocsv: 1.4.0 -> 1.4.1 ``                                                  |
| [`7107e41d`](https://github.com/NixOS/nixpkgs/commit/7107e41d66ab3671b9fe824a6aa9f9b7a55ea513) | `` ip2unix: 2.2.1 -> 2.2.2 ``                                                                 |
| [`b0ca8e91`](https://github.com/NixOS/nixpkgs/commit/b0ca8e91d2e804d2df7dede1de8e155c87cd2445) | `` python3Packages.withings-sync: 5.3.2 -> 6.0.2 ``                                           |
| [`42edbe31`](https://github.com/NixOS/nixpkgs/commit/42edbe3108ecceea70098b98afb7fa7dd9439d14) | `` python3Packages.garminconnect: remove unnecessary withings-sync dependency ``              |
| [`d00c6e09`](https://github.com/NixOS/nixpkgs/commit/d00c6e09404ad231acfacec67253240b831bcbbc) | `` python3Packages.git-url-parse: modernize and migrate to pyproject ``                       |
| [`35441e44`](https://github.com/NixOS/nixpkgs/commit/35441e44e9e0b9fe7f92983c380b4120adf7afe7) | `` python3Packages.unittest-data-provider: drop ``                                            |
| [`e12a3d93`](https://github.com/NixOS/nixpkgs/commit/e12a3d936fa5909f3b417248df1f9a638f1d4724) | `` python3Packages.tstr: 0.4.0.post1 -> 0.4.1 ``                                              |
| [`5471a6a1`](https://github.com/NixOS/nixpkgs/commit/5471a6a1fef474aec83073f39af38f1641968cb2) | `` smpmgr: include all smpclient transports ``                                                |
| [`b5cb6b27`](https://github.com/NixOS/nixpkgs/commit/b5cb6b27f202fc417f9fe78e09af45621816a53c) | `` python3Packages.smp: pin pyproject.toml version ``                                         |
| [`281cf61b`](https://github.com/NixOS/nixpkgs/commit/281cf61b41b35d9bd146d9f5502a7c60f2115d69) | `` python3Packages.smpclient: 6.0.0 -> 7.0.1 ``                                               |
| [`b0015daf`](https://github.com/NixOS/nixpkgs/commit/b0015daf6f63118f98ef4bd287ed6bb66efe3f96) | `` cudaPackages.tensorrt: mark insecure ``                                                    |
| [`997f14e0`](https://github.com/NixOS/nixpkgs/commit/997f14e05930904791153781065d72f7bec51b48) | `` vimcats: 1.1.1 -> 1.2.0 ``                                                                 |
| [`a31044f8`](https://github.com/NixOS/nixpkgs/commit/a31044f84b8fe475c7846925022c0bc83bb462cd) | `` python3Packages.pip-requirements-parser: modernize ``                                      |
| [`e6afb4a3`](https://github.com/NixOS/nixpkgs/commit/e6afb4a32c6891c7b6ede116c3c47663ee50e36e) | `` python3Packages.pip-requirements-parser: fix build with packaging 26 ``                    |
| [`12f94ebc`](https://github.com/NixOS/nixpkgs/commit/12f94ebc9f13187ed82569bfe011673146bdbdae) | `` linuxKernel.kernels.linux_zen: 7.0.9-zen1 -> 7.0.9-zen2 ``                                 |
| [`5e77f648`](https://github.com/NixOS/nixpkgs/commit/5e77f648880ea9bd450b073c16b076f097bf27c4) | `` libaec: switch source to github ``                                                         |
| [`4f46cab3`](https://github.com/NixOS/nixpkgs/commit/4f46cab38cc108f8c7786c5f8b521bac5710617a) | `` aws-sam-cli: 1.154.0 -> 1.160.0 ``                                                         |
| [`b941cbeb`](https://github.com/NixOS/nixpkgs/commit/b941cbeb2ba4afbb5a491d266cac4135762f0c76) | `` python3Packages.crossandra: 2.2.1 -> 2.3.0 ``                                              |
| [`07ab328c`](https://github.com/NixOS/nixpkgs/commit/07ab328c3fbc0ccc18b337adf4a7b2eeb37ae42d) | `` zeekscript: 1.3.4 -> 1.3.6 ``                                                              |
| [`261cdb2d`](https://github.com/NixOS/nixpkgs/commit/261cdb2da56b1d971e6f05c4c6ddf92e43bbe925) | `` dwproton-bin: dwproton-11.0-1 -> dwproton-11.0-2 ``                                        |
| [`72589a56`](https://github.com/NixOS/nixpkgs/commit/72589a5689b9177f2570e908c59fbe2f5d9a8c27) | `` rgl: 0.17.0 -> 0.18.0 ``                                                                   |
| [`4a5eaa76`](https://github.com/NixOS/nixpkgs/commit/4a5eaa766f4c3a5dccb707d7a348ce5b6322ff89) | `` python3Packages.pydantic-ai-slim: 1.97.0 -> 1.101.0 ``                                     |
| [`7f99bf80`](https://github.com/NixOS/nixpkgs/commit/7f99bf800968d81495742d98870571b6a50fe911) | `` python3Packages.pydantic-graph: 1.97.0 -> 1.101.0 ``                                       |
| [`cce18fae`](https://github.com/NixOS/nixpkgs/commit/cce18faeb0179bfe225926c0f2aa9753aefbd404) | `` libretro.prboom: 0-unstable-2026-05-04 -> 0-unstable-2026-05-20 ``                         |
| [`94725a66`](https://github.com/NixOS/nixpkgs/commit/94725a66cee78a982ff055825dc020260c598a0f) | `` home-assistant-custom-lovelace-modules.zigbee2mqtt-networkmap: 0.10.0 -> 0.13.0 ``         |
| [`3a624316`](https://github.com/NixOS/nixpkgs/commit/3a624316e3161cd4550757880bc5ccc51393581d) | `` deja: init at 0.2.6 ``                                                                     |
| [`7a47d24f`](https://github.com/NixOS/nixpkgs/commit/7a47d24ff4d466e8d748f00ff6b0f47158127a94) | `` libretro.mame2000: 0-unstable-2026-03-31 -> 0-unstable-2026-05-22 ``                       |
| [`ec807151`](https://github.com/NixOS/nixpkgs/commit/ec807151c27918395068c66a416e4e269674d421) | `` home-assistant-custom-components.elegoo_printer: 2.8.0 -> 2.9.0 ``                         |
| [`d8663800`](https://github.com/NixOS/nixpkgs/commit/d8663800f6a63c7088e8e2997739bdf0008d54f0) | `` os-agent: 1.8.1 -> 1.9.0 ``                                                                |
| [`b3b4645f`](https://github.com/NixOS/nixpkgs/commit/b3b4645f0cf7c11755bacb7698ad283db7dd3210) | `` xonsh: 0.23.5 -> 0.23.7 ``                                                                 |
| [`1e56caa3`](https://github.com/NixOS/nixpkgs/commit/1e56caa34bb1f9ea0153a641bc8cfcc7ff30d50e) | `` hello: fix translations on FreeBSD ``                                                      |
| [`64819976`](https://github.com/NixOS/nixpkgs/commit/648199765f51aa9c5bfdfeebc8a87f7ffc9dfa1e) | `` python3Packages.homematicip: remove disabled ``                                            |
| [`d49a732b`](https://github.com/NixOS/nixpkgs/commit/d49a732b377ed01c0de2b13c1dde030ca9e6d939) | `` copilot-language-server: 1.487.0 -> 1.495.0 ``                                             |
| [`cbd1db0a`](https://github.com/NixOS/nixpkgs/commit/cbd1db0ad7f6aacdfb8d0b0aa5c97f54089bdf89) | `` hledger-fmt: 0.3.8 -> 0.3.9 ``                                                             |
| [`c1577cf7`](https://github.com/NixOS/nixpkgs/commit/c1577cf7854c7eb645f40061f0920495e2fed9dd) | `` python3Packages.boto3-stubs: 1.43.12 -> 1.43.13 ``                                         |
| [`b3729150`](https://github.com/NixOS/nixpkgs/commit/b37291500529d407fee6a0b3075f6a842dd2e7e9) | `` python3Packages.mypy-boto3-verifiedpermissions: 1.43.0 -> 1.43.13 ``                       |
| [`34095fc5`](https://github.com/NixOS/nixpkgs/commit/34095fc592d37075b5c08333d8514b71d5b0bf49) | `` python3Packages.mypy-boto3-sagemaker: 1.43.11 -> 1.43.13 ``                                |
| [`3f209b16`](https://github.com/NixOS/nixpkgs/commit/3f209b16f95ad6c359712c15e83279904069eebf) | `` python3Packages.mypy-boto3-mediaconnect: 1.43.0 -> 1.43.13 ``                              |
| [`a17af0c8`](https://github.com/NixOS/nixpkgs/commit/a17af0c851314ad03d51da4fa968ca16de997f17) | `` python3Packages.mypy-boto3-cleanrooms: 1.43.0 -> 1.43.13 ``                                |
| [`7a399453`](https://github.com/NixOS/nixpkgs/commit/7a399453100071f5fc8075cde741ba68407f9fd0) | `` python3Packages.mypy-boto3-batch: 1.43.7 -> 1.43.13 ``                                     |
| [`1cf5bc6e`](https://github.com/NixOS/nixpkgs/commit/1cf5bc6ec8a0b69cab870c59d5f920c45645f482) | `` python3Packages.boto3-stubs: 1.43.11 -> 1.43.12 ``                                         |
| [`f0b1566c`](https://github.com/NixOS/nixpkgs/commit/f0b1566cfdadc1c09dd396f15930667266483e0e) | `` python3Packages.mypy-boto3-payment-cryptography-data: 1.43.0 -> 1.43.12 ``                 |
| [`cb20c443`](https://github.com/NixOS/nixpkgs/commit/cb20c443bb0250c44364e58cefa8d3f8a156794a) | `` python3Packages.mypy-boto3-mwaa: 1.43.5 -> 1.43.12 ``                                      |
| [`ba70e71e`](https://github.com/NixOS/nixpkgs/commit/ba70e71e2c5facb5e1dcb5cdcc749711a35e7629) | `` python3Packages.mypy-boto3-kms: 1.43.0 -> 1.43.12 ``                                       |
| [`b46148f6`](https://github.com/NixOS/nixpkgs/commit/b46148f671a2d2c0c7e5ddbc0879977bec9b29e4) | `` python3Packages.mypy-boto3-customer-profiles: 1.43.0 -> 1.43.12 ``                         |
| [`5f8ec489`](https://github.com/NixOS/nixpkgs/commit/5f8ec48914977589b03b019aca46eb519ba74561) | `` python3Packages.iamdata: 0.1.202605211 -> 0.1.202605221 ``                                 |
| [`518bf6c8`](https://github.com/NixOS/nixpkgs/commit/518bf6c8c67858912345caa20e50169ef3e004e9) | `` telemt: 3.4.11 -> 3.4.12 ``                                                                |
| [`9b9d803a`](https://github.com/NixOS/nixpkgs/commit/9b9d803a3b6f585cfa0bc921f0ac6b2860bf094c) | `` poutine: 1.1.4 -> 1.1.5 ``                                                                 |
| [`1097c9d0`](https://github.com/NixOS/nixpkgs/commit/1097c9d03182b6f9882fb41e760788930a11b771) | `` trdl-client: 0.12.2 -> 0.12.3 ``                                                           |
| [`e91ba0d7`](https://github.com/NixOS/nixpkgs/commit/e91ba0d7d23fcb749af8f9c43788ca2c0b9901e2) | `` mangareader: 2.4.0 -> 2.5.0 ``                                                             |
| [`c85c1dcb`](https://github.com/NixOS/nixpkgs/commit/c85c1dcb4b719775c2831413ac48b4373cbdf9f5) | `` evcc: 0.306.3 -> 0.307.0 ``                                                                |
| [`eb51dacc`](https://github.com/NixOS/nixpkgs/commit/eb51dacceaf2746b9001140a83f65e5349cc39bb) | `` _1password-gui: Upstream repackaged without changing version ``                            |
| [`0bf5ad50`](https://github.com/NixOS/nixpkgs/commit/0bf5ad507102b88426d312896f4e903eeb13a6ed) | `` camilladsp: enable darwin build and add maintainer ``                                      |
| [`05b365b4`](https://github.com/NixOS/nixpkgs/commit/05b365b45a7ee27929e1a0a70d9d07413264951f) | `` visual-paradigm-ce: fix passthru.updateScript ``                                           |
| [`24b80c45`](https://github.com/NixOS/nixpkgs/commit/24b80c45f2d5cfd4e8ea7f3a6b04de3e2dfc04c4) | `` nixos/starship: fix '$' escaping for bash and zsh ``                                       |
| [`4fef53db`](https://github.com/NixOS/nixpkgs/commit/4fef53dba2e8925a75c9b707e9e08161e4ef3da5) | `` libcss: vendor patches (no longer exist on server) ``                                      |
| [`2821def9`](https://github.com/NixOS/nixpkgs/commit/2821def9ff628479638a4731695626eca11109a7) | `` nylon: fix build with gcc 15 ``                                                            |
| [`1accb5b5`](https://github.com/NixOS/nixpkgs/commit/1accb5b53a3c47b13e2cec9efa61654f69188c16) | `` libdom: vendor patch (no longer exists on server) ``                                       |
| [`794f5aa0`](https://github.com/NixOS/nixpkgs/commit/794f5aa087eeb0f7b25409281293dfd41b9209d2) | `` libsvgtiny: vendor patch (no longer on server) ``                                          |
| [`08b985a7`](https://github.com/NixOS/nixpkgs/commit/08b985a7ff77f986c7f4b2365a4467ca8a3e9903) | `` libinput: luaSupport flag ``                                                               |
| [`3b649861`](https://github.com/NixOS/nixpkgs/commit/3b64986111a59fddd46c35357916f696bb79afba) | `` libinput: lib.meson* helpers ``                                                            |
| [`d0eb5122`](https://github.com/NixOS/nixpkgs/commit/d0eb512214da0b36bb89b999165069b0988ea38d) | `` visual-paradigm-ce: 18.0.20260303 -> 18.0.20260511 ``                                      |
| [`b204c4ee`](https://github.com/NixOS/nixpkgs/commit/b204c4ee5b0f5b909251baa6793fcee742b7d7d5) | `` spotiflac: 7.1.6 -> 7.1.7 ``                                                               |
| [`d14515c3`](https://github.com/NixOS/nixpkgs/commit/d14515c37b2f458f2637eea1c7b11e1a76ffa7c8) | `` survex: 1.4.20 -> 1.4.21 ``                                                                |
| [`585063e2`](https://github.com/NixOS/nixpkgs/commit/585063e202eac73267bc415d5f74a5b05e7c3cf9) | `` libtapi: fix build with gcc 15 ``                                                          |
| [`47a6a321`](https://github.com/NixOS/nixpkgs/commit/47a6a321a447244d8b70e014134caecfdb26f8d4) | `` python3Packages.cynthion: 0.2.4 -> 0.2.5 ``                                                |
| [`cf416b91`](https://github.com/NixOS/nixpkgs/commit/cf416b91bdd0e2ee3c3cdb94457a1ee5329665bb) | `` nixos/navidrome: Default to plugins enabled ``                                             |
| [`6fa3ef58`](https://github.com/NixOS/nixpkgs/commit/6fa3ef586f526a42b238ec526fd5a554a1797e48) | `` python3Packages.jsbeautifier: modernize and migrate to pyproject ``                        |
| [`5c78890d`](https://github.com/NixOS/nixpkgs/commit/5c78890d4f60fc2bf3f669635fd6747b967232e2) | `` radicle-desktop: 0.10.0 -> 0.11.0 ``                                                       |
| [`66656e87`](https://github.com/NixOS/nixpkgs/commit/66656e87b4c80387c3bc6af969b86e7de47d5c0f) | `` dcp: 0.23.4 -> 0.24.3 ``                                                                   |
| [`6f52b99f`](https://github.com/NixOS/nixpkgs/commit/6f52b99f49d320b1cafdcbff66f182cb658c69cd) | `` macaulay2: added meta.platforms ``                                                         |
| [`e9097092`](https://github.com/NixOS/nixpkgs/commit/e9097092600231738675818711f00704db74696d) | `` mathicgb: added meta.platforms ``                                                          |
| [`effc9c3a`](https://github.com/NixOS/nixpkgs/commit/effc9c3ab7695c0c43217d89f9755c14e96941ae) | `` mathic: added meta.platforms ``                                                            |
| [`0225e5ef`](https://github.com/NixOS/nixpkgs/commit/0225e5efa5d8ca90f74d848906d05297647715b6) | `` frobby: added meta.platforms ``                                                            |
| [`78b1d5b7`](https://github.com/NixOS/nixpkgs/commit/78b1d5b70be5a22b643ec1d189483f0076bdd7f0) | `` cargo-hakari: 0.9.37 -> 0.9.38 ``                                                          |
| [`2f56cbaf`](https://github.com/NixOS/nixpkgs/commit/2f56cbaf8a459897bbe93b52b6d26005e05c2146) | `` gitfs: drop ``                                                                             |
| [`135188a4`](https://github.com/NixOS/nixpkgs/commit/135188a4503ec6e2b6406d4f5a32fabeb062553a) | `` python3Packages.python-homewizard-energy: 10.0.1 -> 10.1.0 ``                              |
| [`52612ae2`](https://github.com/NixOS/nixpkgs/commit/52612ae262354dacb2f29746f82a5d214231b133) | `` moonlight: 2026.5.0 -> 2026.5.2 ``                                                         |
| [`6d462b2d`](https://github.com/NixOS/nixpkgs/commit/6d462b2d090609b74e50d9e778830fbb50a31d4e) | `` thunderkittens: 0-unstable-2026-05-11 -> 0-unstable-2026-05-22 ``                          |
| [`951a1ddc`](https://github.com/NixOS/nixpkgs/commit/951a1ddcf9b6dc13c576d7d0ba2a34ca7810689a) | `` python3Packages.ax-platform: disable tests with are time-sensitive ``                      |
| [`e7023fb8`](https://github.com/NixOS/nixpkgs/commit/e7023fb8c5a84c2e9ae3cfaf812664d61c093e70) | `` glab: 1.97.0 -> 1.99.0 ``                                                                  |
| [`44619b7c`](https://github.com/NixOS/nixpkgs/commit/44619b7c78d87fc0372c310bd9b1671dbe62d025) | `` cabal-fmt: do not override Cabal-syntax ``                                                 |
| [`f7df550f`](https://github.com/NixOS/nixpkgs/commit/f7df550fcbe050d9ad56f523417d8bdf6eac5d11) | `` beamPackages.elixir_1_20: 1.20.0-rc.5 -> 1.20.0-rc.6 ``                                    |
| [`9e0eff34`](https://github.com/NixOS/nixpkgs/commit/9e0eff34c52153a10b1a8adb836c2cbfef9265f5) | `` nixos/test-driver: change run name to distinguish between different kinds of tests ``      |
| [`50ec0ab0`](https://github.com/NixOS/nixpkgs/commit/50ec0ab02a5bdc6af82cb8eb7394d0558746126c) | `` phpExtensions.mongodb: 2.3.1 -> 2.3.3 ``                                                   |
| [`9c42edbc`](https://github.com/NixOS/nixpkgs/commit/9c42edbc847d35e3712f91aa147f1f35fcce7650) | `` python3Packages.tree-sitter-zeek: 0.2.13 -> 0.2.15 ``                                      |
| [`9ffed393`](https://github.com/NixOS/nixpkgs/commit/9ffed393a63f797a98ef78fd0714a082767d17a0) | `` python3Packages.lerobot: 0.5.0 -> 0.5.1 ``                                                 |
| [`497dd138`](https://github.com/NixOS/nixpkgs/commit/497dd138cad7c56aa5ac19ef936b49a875214193) | `` hdf5: fix Darwin dylib install names ``                                                    |
| [`537c2bab`](https://github.com/NixOS/nixpkgs/commit/537c2bab37beec01113f0d981eca257bd7042bd0) | `` oh-my-posh: 29.13.1 -> 29.14.0 ``                                                          |
| [`081b749a`](https://github.com/NixOS/nixpkgs/commit/081b749ad6e7ca2b50a52af6f9a9689195ed7eff) | `` python3Packages.jupyter-collaboration: 4.3.0 -> 4.4.0 ``                                   |
| [`43b38c0b`](https://github.com/NixOS/nixpkgs/commit/43b38c0b623247ab0f163c608d254867c2e1e2f3) | `` esphome: 2026.4.5 -> 2026.5.0 ``                                                           |
| [`5fc76386`](https://github.com/NixOS/nixpkgs/commit/5fc76386cda92aaef5189aade56a2bc96f84c373) | `` ocamlPackages.tls: 2.0.2 → 2.1.0 ``                                                        |
| [`dca146f1`](https://github.com/NixOS/nixpkgs/commit/dca146f185df056f2e182353a6eca0da309dd2b4) | `` crossplane-cli: add myself as maintainer ``                                                |
| [`4952b232`](https://github.com/NixOS/nixpkgs/commit/4952b23233860e4b26ab46ed73a2f66b3a5c6804) | `` crossplane-cli: 2.2.1 -> 2.3.0 ``                                                          |
| [`dcccb23e`](https://github.com/NixOS/nixpkgs/commit/dcccb23e56c849d1cab82b7d1e41875e3ff66a37) | `` perfect_dark: 0-unstable-2026-05-02 -> 0-unstable-2026-05-21 ``                            |
| [`71057a3a`](https://github.com/NixOS/nixpkgs/commit/71057a3a51441633a75c59cca3209399557711b2) | `` python3Packages.google-cloud-secret-manager: 2.27.0 -> 2.28.0 ``                           |
| [`483eb8d6`](https://github.com/NixOS/nixpkgs/commit/483eb8d66a96f448c51f4106c551fc7653377358) | `` vscode-extensions.anthropic.claude-code: 2.1.146 -> 2.1.148 ``                             |
| [`214cfc6c`](https://github.com/NixOS/nixpkgs/commit/214cfc6c70cf5004a287be82b56bd74064454bd5) | `` claude-code: 2.1.146 -> 2.1.148 ``                                                         |
| [`035234f8`](https://github.com/NixOS/nixpkgs/commit/035234f81a0be5e88a77d738d5a33b9a705a1db9) | `` powershell: 7.6.1 -> 7.6.2 ``                                                              |
| [`3f387976`](https://github.com/NixOS/nixpkgs/commit/3f387976f4d15bbe6ae3e9d20c9fa6465222fad8) | `` src-cli: 7.2.1 -> 7.3.0 ``                                                                 |
| [`49c886e5`](https://github.com/NixOS/nixpkgs/commit/49c886e5c17a9a5c52f7547ac0c207d83b3c8672) | `` python3Packages.resvg-py: 0.3.1 -> 0.3.2 ``                                                |
| [`d26b1842`](https://github.com/NixOS/nixpkgs/commit/d26b184247e61fa9d37d7fd8d5ab0925621c2b65) | `` fop: add patch to "fix" maven versions ``                                                  |
| [`fa34339c`](https://github.com/NixOS/nixpkgs/commit/fa34339c18d3ff09cf8f0b58f5170d5fd0a20ffa) | `` flexget: 3.19.17 -> 3.19.21 ``                                                             |
| [`95cca58f`](https://github.com/NixOS/nixpkgs/commit/95cca58f480d55b0e2ac9de42251be1378881633) | `` kanidm_1_10: 1.10.2 -> 1.10.3 ``                                                           |
| [`f8e0f2a0`](https://github.com/NixOS/nixpkgs/commit/f8e0f2a09308ced97db5fc9a9e61041c7d544ea6) | `` dblab: 0.38.0 -> 0.39.0 ``                                                                 |
| [`7e557e7a`](https://github.com/NixOS/nixpkgs/commit/7e557e7ad14c72ba241705a52bd9507180b9a7ab) | `` fetchFromGitHub: only override fetchzip once ``                                            |
| [`6f79f478`](https://github.com/NixOS/nixpkgs/commit/6f79f478cbfd6b36e8e55ced9ade2cdd3601205e) | `` python3Packages.homematicip: 2.11.0 -> 2.12.0 ``                                           |
| [`310ed4e2`](https://github.com/NixOS/nixpkgs/commit/310ed4e2a8719fa71bf1160aeec548b2780d9951) | `` har-to-k6: 0.14.14 -> 0.14.15 ``                                                           |
| [`059edbda`](https://github.com/NixOS/nixpkgs/commit/059edbdafe650eb34c2f504f8b7d9f831f5b2583) | `` codex: 0.131.0 -> 0.133.0 ``                                                               |
| [`b9e0265f`](https://github.com/NixOS/nixpkgs/commit/b9e0265f2f8d201dd56a9fbecf897feaa4ab4b9e) | `` python3Packages.pulsectl: modernize and migrate to pyproject ``                            |
| [`b1eb11bb`](https://github.com/NixOS/nixpkgs/commit/b1eb11bbd0910408590b38f5906d7cd1f2f06e06) | `` n64recomp: 0-unstable-2026-01-17 -> 0-unstable-2026-05-17 ``                               |
| [`2a259335`](https://github.com/NixOS/nixpkgs/commit/2a259335fc0db5f3b7c7bd0078438c8b807d43de) | `` python3Packages.pyfireservicerota: 0.0.47 -> 0.0.48 ``                                     |
| [`ea2bdee0`](https://github.com/NixOS/nixpkgs/commit/ea2bdee030419ca675c4ecd55576484e5187a821) | `` code-cursor: 3.4.16 -> 3.5.17 ``                                                           |
| [`996d8fc8`](https://github.com/NixOS/nixpkgs/commit/996d8fc8cb47a1e8915f5f22121b16abb16f43d1) | `` libphonenumber: 9.0.30 -> 9.0.31 ``                                                        |
| [`8443be28`](https://github.com/NixOS/nixpkgs/commit/8443be281301c17a66069902f03aceeb1c9c501d) | `` vkd3d: 1.19 -> 2.0 ``                                                                      |
| [`36587c86`](https://github.com/NixOS/nixpkgs/commit/36587c86096589ced1392cb2e0bc2045960c0ea2) | `` archisteamfarm: 6.3.4.2 -> 6.3.6.0 ``                                                      |
| [`5eba89ff`](https://github.com/NixOS/nixpkgs/commit/5eba89ff4364dd0632210756da112f57578764e3) | `` nixos/nspawn-container: add "usr/bin" ``                                                   |
| [`9882a4e3`](https://github.com/NixOS/nixpkgs/commit/9882a4e3c715ef2e2ee52f570514e3cfaaf2e456) | `` googleearth-pro: 7.3.6.10201 -> 7.3.7.1155 ``                                              |
| [`8c0ea07a`](https://github.com/NixOS/nixpkgs/commit/8c0ea07af98c2672eefcd08615e57f4e1638ab5b) | `` git-archive-all: switch to pyproject ``                                                    |
| [`474a47a0`](https://github.com/NixOS/nixpkgs/commit/474a47a0b3200a314deca4c99fbf81959306d690) | `` wayfarer: 1.2.4-unstable-2025-04-12 -> 1.4.0 ``                                            |
| [`bf0ecacf`](https://github.com/NixOS/nixpkgs/commit/bf0ecacf6c66a3dee4f32bef19bbd51a006a812d) | `` pgdog: 0.1.40 -> 0.1.41 ``                                                                 |
| [`ecf4b2b1`](https://github.com/NixOS/nixpkgs/commit/ecf4b2b14b0d83b28e330a6721c1b2e6464cf0dd) | `` niimblue: init at 0-unstable-2026-05-04 ``                                                 |
| [`238d721c`](https://github.com/NixOS/nixpkgs/commit/238d721c6913b18625ab26f20116de068e1f71c3) | `` python3Packages.bthome-ble: 3.22.1 -> 3.23.2 ``                                            |
| [`eb9d115a`](https://github.com/NixOS/nixpkgs/commit/eb9d115a7a5cff1abc853076f2d7d158d8569427) | `` sunsetr: 0.11.1 -> 0.12.2 ``                                                               |
| [`43657777`](https://github.com/NixOS/nixpkgs/commit/436577778a7e429aa7af4f6809fa65867616bf34) | `` evince: 48.1 -> 48.4 ``                                                                    |
| [`dbcdf83b`](https://github.com/NixOS/nixpkgs/commit/dbcdf83bb770c06359b8fc662218ad43a983efab) | `` alkalami: use finalAttrs ``                                                                |
| [`76a21af2`](https://github.com/NixOS/nixpkgs/commit/76a21af26670ec8d82c0bef471e8d3642ee2812b) | `` alkalami: use installFonts ``                                                              |
| [`98093105`](https://github.com/NixOS/nixpkgs/commit/980931056eccb1dea2f2e8ce7b26405b31992fe3) | `` installFonts: make preInstall hook ``                                                      |
| [`c4f37e2b`](https://github.com/NixOS/nixpkgs/commit/c4f37e2b31e063863d78474396ffc2bcf3da96d2) | `` python3Packages.ax-platform: disable failing test ``                                       |
| [`02a6844d`](https://github.com/NixOS/nixpkgs/commit/02a6844d57be1b1aea87e3d64a009a3071774565) | `` json-sort: 1.1.0 -> 1.1.5 ``                                                               |
| [`d2eb1ebf`](https://github.com/NixOS/nixpkgs/commit/d2eb1ebfc2b71462b3431a49fab5aa512194bb04) | `` mup: fix build with gcc 15 ``                                                              |
| [`279f0df0`](https://github.com/NixOS/nixpkgs/commit/279f0df0b1e4773f9ad9f99c7eb7f9c7f0cb63b9) | `` gpxsee: 16.6 -> 16.7 ``                                                                    |
| [`4539a5b8`](https://github.com/NixOS/nixpkgs/commit/4539a5b8218a0caaac5ae89c9d4fbc5133f2e21a) | `` ollama: 0.23.4 -> 0.24.0 ``                                                                |
| [`1cf0065f`](https://github.com/NixOS/nixpkgs/commit/1cf0065f1804b9a0a2a0b5dbc79bd5945b360973) | `` dmensamenu: migrate to pyproject ``                                                        |
| [`391e8921`](https://github.com/NixOS/nixpkgs/commit/391e892124f1cd78d9b1432fbd9a4f0e3e825f20) | `` displaycal: migrate to pyproject ``                                                        |
| [`30a93455`](https://github.com/NixOS/nixpkgs/commit/30a934559fbd1e21193de0f61047e10707e17cb4) | `` _1password-gui-beta: 8.12.12-43.BETA -> 8.12.22-15.BETA ``                                 |
| [`a5209d05`](https://github.com/NixOS/nixpkgs/commit/a5209d05eeaa64e08c1de3113715164c9c90d559) | `` python3Packages.pyvista: 0.48.2 -> 0.48.4 ``                                               |
| [`dbe7e407`](https://github.com/NixOS/nixpkgs/commit/dbe7e407cfb6c55003628b5990debfb7de7fd85e) | `` python3Packages.vector: 1.8.0 -> 1.8.1 ``                                                  |
| [`0d277679`](https://github.com/NixOS/nixpkgs/commit/0d277679c03180711bb98e851e1b9fdf587c1cc2) | `` maintainers: remove davisrichard437 ``                                                     |
| [`91a0d7b9`](https://github.com/NixOS/nixpkgs/commit/91a0d7b98ed492d8d04c706bb30a5210a3f609ce) | `` terraform-providers.yandex-cloud_yandex: 0.202.0 -> 0.204.0 ``                             |
| [`57d93f0b`](https://github.com/NixOS/nixpkgs/commit/57d93f0b835c483607791684ad3d813834107a46) | `` nixos/hyprland: link lua stubs ``                                                          |
| [`604f7cdf`](https://github.com/NixOS/nixpkgs/commit/604f7cdfa17a78342736dce2dca69033da828580) | `` gitea: 1.26.1 -> 1.26.2 ``                                                                 |
| [`83c59da4`](https://github.com/NixOS/nixpkgs/commit/83c59da4dae0ae2d784ce2439ad45fb6ff048741) | `` igraph: enable (and fix) html documentation generation ``                                  |
| [`d4125265`](https://github.com/NixOS/nixpkgs/commit/d412526504fc4cd46650be22071a762dd4e05494) | `` ddhx: 0.9.2 -> 0.9.3 ``                                                                    |
| [`d817bf83`](https://github.com/NixOS/nixpkgs/commit/d817bf83c7d55984a5ef3fa98f83fda3ebca3393) | `` dnsproxy: 0.81.3 -> 0.81.4 ``                                                              |
| [`6849aad8`](https://github.com/NixOS/nixpkgs/commit/6849aad8c63b4a2e7184cbd029fbdd091122b95b) | `` python3Packages.language-tool-python: 3.3.1 -> 3.4.0 ``                                    |
| [`37413baa`](https://github.com/NixOS/nixpkgs/commit/37413baa3a41291aaa6bb091ca94a0b4f9b0eea9) | `` vdr-streamdev: 0.6.4 -> 0.6.5 ``                                                           |
| [`68e9f5ed`](https://github.com/NixOS/nixpkgs/commit/68e9f5ed8f9db8392c8b170227f688db5be0ec93) | `` vdr-vnsiserver: 1.8.3 -> 1.8.4 ``                                                          |
| [`62785fc7`](https://github.com/NixOS/nixpkgs/commit/62785fc7f7159f469d8ddf7365aa821b9f2722a5) | `` vdr-skin-nopacity: 1.1.19 -> 1.1.20 ``                                                     |
| [`195352a9`](https://github.com/NixOS/nixpkgs/commit/195352a9b27b9e91b9dc6c6c893cbb8291c69439) | `` vdr-markad: 4.2.19 -> 4.2.22 ``                                                            |
| [`63710c9d`](https://github.com/NixOS/nixpkgs/commit/63710c9d9ed94d1baedd8df6766fd53304a8daaf) | `` ndg: init at 2.8.0 ``                                                                      |
| [`d373280b`](https://github.com/NixOS/nixpkgs/commit/d373280bd0305e6ddb993c34c11e267df89718c2) | `` vscode-extensions: Skips marketplace validation-failed extension versions ``               |
| [`8459e001`](https://github.com/NixOS/nixpkgs/commit/8459e001cacf5d6a7917faad00626e1ac08c70a6) | `` yabai: 7.1.24 -> 7.1.25 ``                                                                 |
| [`0f6752ac`](https://github.com/NixOS/nixpkgs/commit/0f6752acaf40e84b61a75345feeb409e9836ac4e) | `` python3Packages.urllib3-future: 2.20.905 -> 2.20.906 ``                                    |
| [`2218a58c`](https://github.com/NixOS/nixpkgs/commit/2218a58c1519a6b19f70ee69fa1b027d442bfbb3) | `` kitty: 0.46.2 -> 0.47.0 ``                                                                 |
| [`f23b117e`](https://github.com/NixOS/nixpkgs/commit/f23b117e50f3742b1b29d46d27898d4c2d8e0d31) | `` lib.showWarnings: inherit lib functions, beta reduce for free ``                           |
| [`59d05494`](https://github.com/NixOS/nixpkgs/commit/59d054945fe4163e2b3ad75cc954e9071d96095c) | `` go-jet: 2.14.1 -> 2.15.0 ``                                                                |
| [`47508449`](https://github.com/NixOS/nixpkgs/commit/47508449e35008d702cf4c25ffc233b15f1a9b2b) | `` glaze: 7.6.0 -> 7.7.0 ``                                                                   |
| [`7f6eb89a`](https://github.com/NixOS/nixpkgs/commit/7f6eb89aeb1220bfa25e6ad9e3290c4607d70452) | `` lib.{importJSON,importTOML}: inherit builtins to global scope ``                           |
| [`f023dff3`](https://github.com/NixOS/nixpkgs/commit/f023dff3203790816afd8c350a229b8bee24ae2b) | `` gotlsaflare: 2.8.2 -> 2.8.3 ``                                                             |
| [`0a4c1584`](https://github.com/NixOS/nixpkgs/commit/0a4c158427a9f0ff08d6bb46d9d133be1093ae84) | `` igraph: remove unused fop dependency ``                                                    |
| [`1f83c2cc`](https://github.com/NixOS/nixpkgs/commit/1f83c2cc226b4f96e36d42c4a5341fe1fd155e60) | `` lib.toBaseDigits: avoid reversing list ``                                                  |
| [`19fcf500`](https://github.com/NixOS/nixpkgs/commit/19fcf5006ab7a2b131b91f0fe37411bfee467f23) | `` lib.mirrorFunctionArgs: inline call to setFunctionArgs ``                                  |
| [`d02c939b`](https://github.com/NixOS/nixpkgs/commit/d02c939bfc2b22f64b778532f0dc4c98f03c2241) | `` aider-chat: add missing rsa dependency to fix build ``                                     |
| [`cbe17527`](https://github.com/NixOS/nixpkgs/commit/cbe1752727e6b1d1830197bddd843c733e8c0414) | `` muffet: 2.11.3 -> 2.11.4 ``                                                                |
| [`102913e7`](https://github.com/NixOS/nixpkgs/commit/102913e76f1e34d601c77eacd1dbc6f56acc18b1) | `` sqlint: update deps to fix build failure ``                                                |
| [`732700f5`](https://github.com/NixOS/nixpkgs/commit/732700f57744fbf0a27e6af3fb79a1c1e314abe6) | `` openorbitaloptimizer: 0.2.0 -> 0.3.0 ``                                                    |
| [`dad9d362`](https://github.com/NixOS/nixpkgs/commit/dad9d362247d501f692a6e1254e1e60ca02cbf91) | `` apkeditor: 1.4.8 -> 1.4.9 ``                                                               |
| [`ec524ede`](https://github.com/NixOS/nixpkgs/commit/ec524ede460193af2921d403afb944b9affc6afa) | `` vscode-extensions.csharpier.csharpier-vscode: 10.0.2 -> 10.0.3 ``                          |
| [`f04d36a8`](https://github.com/NixOS/nixpkgs/commit/f04d36a8d3580b096305a30aec2da90bf464495c) | `` lunar-client: 3.6.10 -> 3.6.11 ``                                                          |
| [`0f965ef1`](https://github.com/NixOS/nixpkgs/commit/0f965ef19b3b53dae3ec72461cf99ebf0012722e) | `` home-assistant-custom-components.dreo: 1.8.8 -> 1.9.0 ``                                   |
| [`309d5c16`](https://github.com/NixOS/nixpkgs/commit/309d5c169b871f8b0584ab93132d02067a682b42) | `` doc: don't use sha256 and non-sri hashes in user docs ``                                   |
| [`6b9bcbfc`](https://github.com/NixOS/nixpkgs/commit/6b9bcbfc5f1192c63897265d19217e1eb41fea2f) | `` terraform-providers.tencentcloudstack_tencentcloud: 1.82.93 -> 1.82.95 ``                  |
| [`b142cf26`](https://github.com/NixOS/nixpkgs/commit/b142cf26b3ea9a24bcf809d5524a3dea30e1b6ee) | `` meshtasticd: 2.7.18.fb3bf78 -> 2.7.23.b246bcd ``                                           |
| [`8dff08cb`](https://github.com/NixOS/nixpkgs/commit/8dff08cb12c3945ee3ce90ddfc8e1fe4cbc57b17) | `` opencode: 1.15.5 -> 1.15.7 ``                                                              |
| [`94e94355`](https://github.com/NixOS/nixpkgs/commit/94e943555e5ca44d08d0edfa7386179da80901dc) | `` firefox-bin-unwrapped: 151.0 -> 151.0.1 ``                                                 |
| [`c335effc`](https://github.com/NixOS/nixpkgs/commit/c335effce2c24d0249367f02d43c5087605a408b) | `` python3Packages.jupyter-collaboration-ui: 2.3.0 -> 2.4.0 ``                                |
| [`296ec5dc`](https://github.com/NixOS/nixpkgs/commit/296ec5dc4a2fccefadd3d697be04e142290db940) | `` firefox-unwrapped: 151.0 -> 151.0.1 ``                                                     |
| [`f5dfa65f`](https://github.com/NixOS/nixpkgs/commit/f5dfa65f33c696db72fe0712ce076818556bb54f) | `` cargo-about: 0.8.4 -> 0.9.0 ``                                                             |
| [`2ab21967`](https://github.com/NixOS/nixpkgs/commit/2ab2196703321019d50ce69bcfac9e925f3aafa1) | `` python3Packages.elevenlabs: 2.47.0 -> 2.49.1 ``                                            |
| [`28c08bac`](https://github.com/NixOS/nixpkgs/commit/28c08bac76ee9f367a418bf21a53e78e323ec07e) | `` python3Packages.telnetlib3: 4.0.2 -> 4.0.3 ``                                              |
| [`8a2a19a9`](https://github.com/NixOS/nixpkgs/commit/8a2a19a976cfb5937c1b524bd314a15aa1bb35d8) | `` python3Packages.serialx: 1.7.3 -> 1.8.0 ``                                                 |
| [`5792087b`](https://github.com/NixOS/nixpkgs/commit/5792087ba6ea61836e7c74bce2d76309b3fbb55b) | `` python3Packages.marisa-trie: fix tests with marisa 0.3.1 ``                                |
| [`e3721159`](https://github.com/NixOS/nixpkgs/commit/e3721159a3d5244439d00da75621c26f0792a452) | `` marisa: 0.3.0 -> 0.3.1 ``                                                                  |
| [`d93d8ef2`](https://github.com/NixOS/nixpkgs/commit/d93d8ef251d1cee9d6b6f7adfc15c70f14045513) | `` crush: 0.65.3 -> 0.70.0 ``                                                                 |
| [`cd3470e9`](https://github.com/NixOS/nixpkgs/commit/cd3470e97cf54b53085ea53cdd806d248ae9a2f4) | `` radicle-node-unstable: 1.9.0 -> 1.9.1 ``                                                   |
| [`13cf045f`](https://github.com/NixOS/nixpkgs/commit/13cf045fab0275da50052d4ca629e94dada3652c) | `` radicle-node: 1.9.0 -> 1.9.1 ``                                                            |
| [`cd227f34`](https://github.com/NixOS/nixpkgs/commit/cd227f34532c0c4dfe6bac453b70a4214cf4bf05) | `` python3Packages.apache-beam: 2.72.0 -> 2.73.0 ``                                           |
| [`edbcbb74`](https://github.com/NixOS/nixpkgs/commit/edbcbb74270c6ddb550fb8e6cd9978b21f38f556) | `` uiua-unstable: 0.18.1 -> 0.19.0-dev.4 ``                                                   |
| [`ff39afcc`](https://github.com/NixOS/nixpkgs/commit/ff39afccf0358be9acb0d86c899499c829d83abc) | `` python3Packages.prowlpy: use finalAttrs ``                                                 |
| [`782273bd`](https://github.com/NixOS/nixpkgs/commit/782273bd1da7df2dd1e389013f2c5416c8af4b13) | `` python3Packages.prowlpy: 2.0.0 -> 2.0.1 ``                                                 |
| [`d0cfd633`](https://github.com/NixOS/nixpkgs/commit/d0cfd63368255c2cf1a995308a3a515809802747) | `` meshtasticd: Override download cache timestamps to prevent update attempts during build `` |
| [`930cee13`](https://github.com/NixOS/nixpkgs/commit/930cee135f703121879d13150be8123b19d72994) | `` memtailor: added meta.platforms ``                                                         |
| [`14bbea9b`](https://github.com/NixOS/nixpkgs/commit/14bbea9b4d953c603012db3fc7a4762c6c78b648) | `` kubernix: 0.3.1 -> 0.3.2 ``                                                                |
| [`9727011f`](https://github.com/NixOS/nixpkgs/commit/9727011f5bfbca705e7ac10700d94b27211c67bf) | `` cohomcalg: added meta.platforms ``                                                         |
| [`0d2135b4`](https://github.com/NixOS/nixpkgs/commit/0d2135b47961b09bb58802a228567cfbf47d6a4c) | `` topcom: added meta.platforms ``                                                            |
| [`e6676c3d`](https://github.com/NixOS/nixpkgs/commit/e6676c3d0df38dfa5ecba1bd7048654bd990a55b) | `` python3Packages.pyvlx: 0.2.33 -> 0.2.34 ``                                                 |
| [`87c3e448`](https://github.com/NixOS/nixpkgs/commit/87c3e4487570ce5ffd88bf1a5e30618125c18b82) | `` openocd-adi: init at 0.12.0-1.3.1-1 ``                                                     |
| [`9eafef29`](https://github.com/NixOS/nixpkgs/commit/9eafef29ddedb5c949d3af13577dfde138943627) | `` scala-cli: 1.13.0 -> 1.14.0 ``                                                             |
| [`5b265d33`](https://github.com/NixOS/nixpkgs/commit/5b265d330a1bc243d4db618080dc263d639feb3c) | `` openocd: enable strictDeps and structured attrs ``                                         |
| [`77d60ac2`](https://github.com/NixOS/nixpkgs/commit/77d60ac29bfbe05eb6010dace6c2dedadf956d78) | `` terraform-providers.aminueza_minio: 3.35.1 -> 3.37.0 ``                                    |
| [`267ca677`](https://github.com/NixOS/nixpkgs/commit/267ca6773aaf73a6a7333353e1c4fb5997e643c9) | `` complgen: 0.10.0 -> 0.10.1 ``                                                              |
| [`28834630`](https://github.com/NixOS/nixpkgs/commit/28834630f98e65104758c31489147a7d59013392) | `` python3Packages.mpmath: skip failing test on x86_64-darwin ``                              |
| [`4b8c09e8`](https://github.com/NixOS/nixpkgs/commit/4b8c09e8048936e1dccc73f8621449b3003e7077) | `` python3Packages.aiorwlock: migrate to finalAttrs ``                                        |
| [`26200906`](https://github.com/NixOS/nixpkgs/commit/26200906e964424745bcfb597c522bf97f9e0746) | `` python3Packages.aiorwlock: 1.5.0 -> 1.5.1 ``                                               |
| [`56a2659d`](https://github.com/NixOS/nixpkgs/commit/56a2659de8a5e131bdf3458f044b2fd5c61c14cd) | `` zapzap: 6.4.1 -> 6.4.2 ``                                                                  |
| [`159a9ea5`](https://github.com/NixOS/nixpkgs/commit/159a9ea54b455c4d49e13ceb2a627d1684e80161) | `` python3Packages.yfinance: 1.2.0 -> 1.3.0 ``                                                |
| [`6361e3a8`](https://github.com/NixOS/nixpkgs/commit/6361e3a8612fa0029b524d91073493d753e7e294) | `` opencloud.web: 7.0.0 -> 7.0.1 ``                                                           |
| [`074afb16`](https://github.com/NixOS/nixpkgs/commit/074afb16102607734e336a5d09ff05126078e917) | `` opencloud: 6.2.0 -> 7.0.0 ``                                                               |
| [`2aba8c3e`](https://github.com/NixOS/nixpkgs/commit/2aba8c3e0989d90074742064a1f8e775d5e64109) | `` spyder: relax jedi constraint ``                                                           |
| [`39884acc`](https://github.com/NixOS/nixpkgs/commit/39884accea949d6eb770074a7243b62942e191e1) | `` python3Packages.torch-cluster: 2.6.3-unstable-2026-03-26 -> 1.6.3-unstable-2026-03-26 ``   |
| [`8a4307fe`](https://github.com/NixOS/nixpkgs/commit/8a4307fe6c719821602e6b1b3dcb183cd620737d) | `` devin-cli: 2026.5.6-8 -> 2026.5.6-10 ``                                                    |
| [`e8d35854`](https://github.com/NixOS/nixpkgs/commit/e8d3585438e80dc5527e7de7617fa21a17c832ee) | `` python3Packages.cyscale: 0.3.2 -> 0.4.0 ``                                                 |
| [`d7a03981`](https://github.com/NixOS/nixpkgs/commit/d7a03981c1ceddf5d4bd6c777f61b264c8d750a3) | `` python3Packages.python-lsp-server: fix test with jedi 0.20.0 ``                            |
| [`653d30c9`](https://github.com/NixOS/nixpkgs/commit/653d30c9ee304c69b2b75ca04eb7671afea396f5) | `` sumo: 1.26.0 -> 1.27.0 ``                                                                  |
| [`3a616945`](https://github.com/NixOS/nixpkgs/commit/3a61694574e6c72f3f318817c656e4c6ae6a5ab9) | `` butane: 0.27.0 -> 0.28.0 ``                                                                |
| [`8774183a`](https://github.com/NixOS/nixpkgs/commit/8774183a49f9a3325cf6db16c231473dd7c64dcc) | `` clap: 1.2.7 -> 1.2.8 ``                                                                    |
| [`af0befbe`](https://github.com/NixOS/nixpkgs/commit/af0befbe148deaab75527d56f1438c37c815b09e) | `` gh-markdown-preview: 1.11.0 -> 1.11.1 ``                                                   |
| [`74c17aea`](https://github.com/NixOS/nixpkgs/commit/74c17aeac8b1d3563968c237bfefd9e2b38fe315) | `` treewide: move to by-name part 4 ``                                                        |
| [`26e70ba0`](https://github.com/NixOS/nixpkgs/commit/26e70ba0151ff35119122f05c26da4a315f2dcc1) | `` terraform-providers.hashicorp_aws: 6.44.0 -> 6.46.0 ``                                     |
| [`d8535d75`](https://github.com/NixOS/nixpkgs/commit/d8535d75af54945b59a55cc9929a701e3955f2ee) | `` terraform-providers.datadog_datadog: 4.8.0 -> 4.10.0 ``                                    |
| [`046745b5`](https://github.com/NixOS/nixpkgs/commit/046745b5dea70fd15fa31cfaa778695b67429677) | `` python3Packages.geometric: 1.1 -> 1.1.1 ``                                                 |
| [`7d9ddea4`](https://github.com/NixOS/nixpkgs/commit/7d9ddea4ad310d95dd39a4c0394c60dda6d9e567) | `` doggo: 1.1.5 -> 1.1.6 ``                                                                   |
| [`1ad0eef1`](https://github.com/NixOS/nixpkgs/commit/1ad0eef149385f7080b1c4e381af730e4c625a68) | `` just-lsp: 0.4.4 -> 0.4.5 ``                                                                |
| [`50f8e735`](https://github.com/NixOS/nixpkgs/commit/50f8e73559165e50f185b1a5451612cc392272dd) | `` xen: Use OVMF-xen (`OvmfXen`) instead of generic OVMF `OvmfPkgX64` ``                      |
| [`01f3e47b`](https://github.com/NixOS/nixpkgs/commit/01f3e47b8ad52aa9e18900bdf5c4c48183b36ee1) | `` fcp: init @ 0.2.2 ``                                                                       |
| [`3dc2becc`](https://github.com/NixOS/nixpkgs/commit/3dc2beccf361e7ffe31924f9a6d180cd426d2da3) | `` werf: 2.65.4 -> 2.68.2 ``                                                                  |
| [`5476d3d3`](https://github.com/NixOS/nixpkgs/commit/5476d3d39818b406788baf554ffb66600c12a583) | `` python3Packages.gpytorch: relax mpmath ``                                                  |
| [`24208fbf`](https://github.com/NixOS/nixpkgs/commit/24208fbf36e081d9923756493ff58271566db223) | `` OVMF-xen: init ``                                                                          |
| [`e4bf7895`](https://github.com/NixOS/nixpkgs/commit/e4bf789512e0eba2eb52c40504eebfc723c5491e) | `` lazyworktree: 1.45.1 -> 1.46.0 ``                                                          |
| [`e466ba3a`](https://github.com/NixOS/nixpkgs/commit/e466ba3a582883573c281b1b37920fdcadb648e1) | `` phpdocumentor: 3.9.1 -> 3.10.0 ``                                                          |
| [`2e469c0e`](https://github.com/NixOS/nixpkgs/commit/2e469c0eff1f7d5da59dcf879d6e3c9be63fae07) | `` python3Packages.executorch: enable __structuredAttrs ``                                    |
| [`1735a1b3`](https://github.com/NixOS/nixpkgs/commit/1735a1b3bc6b56175eb0a3ada6c6fd894d2d95af) | `` python3Packages.executorch: relax mpmath ``                                                |
| [`49fa88dc`](https://github.com/NixOS/nixpkgs/commit/49fa88dced570e17226376e8c11b1d56b4db8346) | `` python3Packages.mlflow: enable __structuredAttrs ``                                        |
| [`c96850e6`](https://github.com/NixOS/nixpkgs/commit/c96850e668613bdc18b54ded0854ce05b8aac717) | `` python3Packages.mlflow: relax cryptography ``                                              |
| [`a0742edc`](https://github.com/NixOS/nixpkgs/commit/a0742edc801a3391ef80d450b94729eca78b8a42) | `` python3Packages.sigstore: 4.1.0 -> 4.2.0 ``                                                |
| [`c56ce7ab`](https://github.com/NixOS/nixpkgs/commit/c56ce7aba5b9ccf9513c4f858e7f0b89762e8a2e) | `` python3Packages.sigstore: relax cryptography ``                                            |
| [`669a6450`](https://github.com/NixOS/nixpkgs/commit/669a64507ac3ef55f1283d984711d239febea277) | `` python3Packages.sigstore: enable __structuredAttrs ``                                      |
| [`b78d988f`](https://github.com/NixOS/nixpkgs/commit/b78d988f33449dacd438a15db6aefbcb41f0982a) | `` sirius: fix build with rocm support ``                                                     |
| [`35f06019`](https://github.com/NixOS/nixpkgs/commit/35f060192c19795594ec7079f87308637f5d7aec) | `` netbird: prefix version with "v" ``                                                        |
| [`e4d57ecb`](https://github.com/NixOS/nixpkgs/commit/e4d57ecbf734a839afd10882bdf638ab986c1ffd) | `` netbird-dashboard: 2.38.0 -> 2.38.1 ``                                                     |
| [`808c15d7`](https://github.com/NixOS/nixpkgs/commit/808c15d73d6beed74f26083108f389d096b61b1f) | `` python3Packages.types-aiobotocore-*: 3.2.1 -> 3.7.0 ``                                     |
| [`0669f275`](https://github.com/NixOS/nixpkgs/commit/0669f27508ebb8b1f09623f8495ffd4c4a87f150) | `` github-copilot-cli: add me-and as maintainer ``                                            |
| [`e171111c`](https://github.com/NixOS/nixpkgs/commit/e171111cc15631d1917d8a84ab2ab5b8a0c74f1f) | `` github-copilot-cli: improve dependency handling ``                                         |
| [`141dde13`](https://github.com/NixOS/nixpkgs/commit/141dde132f42c07618b026544a9ef608eae4cbbd) | `` exegol: relax cryptography ``                                                              |
| [`b1997e28`](https://github.com/NixOS/nixpkgs/commit/b1997e289085b385ad6d9afc5dc84efbb68b6d5a) | `` libretro.play: 0-unstable-2026-05-11 -> 0-unstable-2026-05-16 ``                           |
| [`aa92689c`](https://github.com/NixOS/nixpkgs/commit/aa92689cd9ade9968b0f28fa107fd70f6b0ca7d2) | `` vivaldi: 7.9.3970.67 -> 8.0.4033.26 ``                                                     |
| [`ef14c7bd`](https://github.com/NixOS/nixpkgs/commit/ef14c7bd78ae5acf9545b3cb35992a0c5a16d53f) | `` gtk4: fixup build on i686-linux ``                                                         |
| [`e49ebae1`](https://github.com/NixOS/nixpkgs/commit/e49ebae197047ca0c3937c0815bb33ddd9ffa430) | `` selene: 0.30.1 -> 0.31.0 ``                                                                |
| [`4e272434`](https://github.com/NixOS/nixpkgs/commit/4e2724348c58d4583b7372f1609ce54c783b531e) | `` prometheus-redis-exporter: 1.83.0 -> 1.84.0 ``                                             |
| [`959939a1`](https://github.com/NixOS/nixpkgs/commit/959939a107a0198836e27b4dc5fa63f03a9597b7) | `` python3Packages.pytelegrambotapi: migrate to finalAttrs ``                                 |
| [`a33a7811`](https://github.com/NixOS/nixpkgs/commit/a33a781193f516e4d09c477b824038ba927efcc1) | `` mcp-server-sequential-thinking: fix `meta.mainProgram` ``                                  |
| [`13781aea`](https://github.com/NixOS/nixpkgs/commit/13781aea440a324db51840ccc09d9a7c4889822c) | `` mailspring: 1.21.0 -> 1.21.1 ``                                                            |
| [`f2243341`](https://github.com/NixOS/nixpkgs/commit/f2243341f903e9ca55113b42b230fd2a758d8d8a) | `` python3Packages.pytelegrambotapi: 4.30.0 -> 4.33.0 ``                                      |
| [`df0b358d`](https://github.com/NixOS/nixpkgs/commit/df0b358d7ddaa9e6641c39c66fcdcf2ab004ad92) | `` python3Packages.pontos: 26.4.3 -> 26.5.0 ``                                                |
| [`ad85c4cc`](https://github.com/NixOS/nixpkgs/commit/ad85c4cc803ecfc9dc1f5314a9a4b35b7b59f15b) | `` python3Packages.ohme: 1.9.0 -> 1.9.1 ``                                                    |
| [`5c35c9ca`](https://github.com/NixOS/nixpkgs/commit/5c35c9ca145c3c1145a832abc489dfa6f481c1f0) | `` mcp-server-time: fix `meta.mainProgram` ``                                                 |
| [`9d3598ae`](https://github.com/NixOS/nixpkgs/commit/9d3598aee98336c784a3ffb7d0387c554248900a) | `` python3Packages.hydra-core: enable __structuredAttrs ``                                    |
| [`52af3571`](https://github.com/NixOS/nixpkgs/commit/52af357125527f5054628017d27b5553e41e9b38) | `` pvetui: 1.3.2 -> 1.3.3 ``                                                                  |
| [`88d5a339`](https://github.com/NixOS/nixpkgs/commit/88d5a339990262b86cecbf52e41a311b5af72d6d) | `` protoc-gen-connect-go: 1.19.2 -> 1.20.0 ``                                                 |
| [`b7be4527`](https://github.com/NixOS/nixpkgs/commit/b7be4527616dd25a722dc3eeaa5bd2294535008a) | `` plantuml-server: 1.2026.2 -> 1.2026.3 ``                                                   |
| [`2193d15a`](https://github.com/NixOS/nixpkgs/commit/2193d15ada5441ca220c3cd3ee24486934c7480c) | `` pykickstart: 3.72 -> 3.73 ``                                                               |
| [`5bcb9d92`](https://github.com/NixOS/nixpkgs/commit/5bcb9d92e6ee3d2686db97b3074b39add0c5ebb4) | `` python3Packages.hydra-core: skip failing test ``                                           |
| [`f3f29b79`](https://github.com/NixOS/nixpkgs/commit/f3f29b79123c4cf56290e02a5a9736ac6a954617) | `` python3Packages.pydocket: 0.20.1 -> 0.20.2 ``                                              |
| [`46c035a0`](https://github.com/NixOS/nixpkgs/commit/46c035a08ddbe2f6511550410bb18e706c41b513) | `` python3Packages.orbax-checkpoint: 0.11.39 -> 0.11.40 ``                                    |
| [`9479879f`](https://github.com/NixOS/nixpkgs/commit/9479879fdc73251fb54343a5a190d7c47b8975ff) | `` python3Packages.django-markdownify: 0.9.6 -> 0.9.7 ``                                      |
| [`e8b6233f`](https://github.com/NixOS/nixpkgs/commit/e8b6233f23671156b509260ec8c0c7281cceca40) | `` python3Packages.genai-prices: 0.0.60 -> 0.0.61 ``                                          |
| [`7f6a6b5d`](https://github.com/NixOS/nixpkgs/commit/7f6a6b5d417d6be26d7c36a02d0131f076fb025b) | `` betterleaks: 1.2.0 -> 1.3.0 ``                                                             |
| [`3a261ccb`](https://github.com/NixOS/nixpkgs/commit/3a261ccb0f4482729a3c3a858fae6359094f1592) | `` vscode-extensions.anthropic.claude-code: 2.1.145 -> 2.1.146 ``                             |
| [`bbca971d`](https://github.com/NixOS/nixpkgs/commit/bbca971db9be0fb2429fafd0b193f1f9c3ef04e2) | `` claude-code: 2.1.145 -> 2.1.146 ``                                                         |
| [`9e0d1d46`](https://github.com/NixOS/nixpkgs/commit/9e0d1d46d3e67c19dda365641a35dd80e7202dd1) | `` python3Packages.aiostreammagic: 2.13.0 -> 2.13.1 ``                                        |
| [`93d31acb`](https://github.com/NixOS/nixpkgs/commit/93d31acbf1cebb6aa9dd8d6702e0443dbe8b765d) | `` olivetin-3k: 3000.11.3 -> 3000.12.0 ``                                                     |
| [`dbd54065`](https://github.com/NixOS/nixpkgs/commit/dbd54065ba3a83112343735377f96f328d60f7f9) | `` python3Packages.dtfabric: 20260411 -> 20260506 ``                                          |
| [`8a02e5b9`](https://github.com/NixOS/nixpkgs/commit/8a02e5b9447eb524b60bb920baaf02790d5c90e3) | `` netbird: 0.71.2 -> 0.71.3 ``                                                               |
| [`c7a9590e`](https://github.com/NixOS/nixpkgs/commit/c7a9590e18628db6761d1e840f95da23d3aaa1f1) | `` python3Packages.smolagents: 1.24.0 -> 1.25.0 ``                                            |
| [`7533285d`](https://github.com/NixOS/nixpkgs/commit/7533285def640223b6dd5f32a1d21fd63c9f4b1c) | `` home-assistant-custom-components.plant: 2026.5.0 -> 2026.5.1 ``                            |
| [`40914650`](https://github.com/NixOS/nixpkgs/commit/40914650d0edfdc3710de6285eaa177d151bb4c3) | `` python313Packages.rouge-score: migrate to finalAttrs ``                                    |
| [`a1b0133f`](https://github.com/NixOS/nixpkgs/commit/a1b0133fb2556f33de27e05f7508375e93edcd86) | `` python3Packages.pyjson5: 2.0.0 -> 2.0.1 ``                                                 |
| [`af0c591f`](https://github.com/NixOS/nixpkgs/commit/af0c591f0aca88484435ab28373957d6c5eb0a3f) | `` python3Packages.primp: 1.2.3 -> 1.3.0 ``                                                   |
| [`be0048ac`](https://github.com/NixOS/nixpkgs/commit/be0048ac98f0c6eb1ef728c3046798c1deb29e0a) | `` python3Packages.aioghost: 0.4.14 -> 0.4.16 ``                                              |
| [`86ada36e`](https://github.com/NixOS/nixpkgs/commit/86ada36e02c35a9d47efc886682bc1bd10bed163) | `` build-support/vm: fix unpopulated `debsGrouped` after structuredAttrs refactor ``          |
| [`4c1102e4`](https://github.com/NixOS/nixpkgs/commit/4c1102e499dce83c3fc046d888d2268b6711de42) | `` python3Packages.tencentcloud-sdk-python: 3.1.99 -> 3.1.101 ``                              |
| [`6dc13b3e`](https://github.com/NixOS/nixpkgs/commit/6dc13b3e1314cacdb32e38e784e10344b0b60c4c) | `` python3Packages.iamdata: 0.1.202605201 -> 0.1.202605211 ``                                 |
| [`188fe4bc`](https://github.com/NixOS/nixpkgs/commit/188fe4bc87d6fe5ba1854ec6d5bb2c06ab41b98f) | `` gtk-gnutella: 1.2.2 -> 1.3.1 ``                                                            |
| [`5af886c5`](https://github.com/NixOS/nixpkgs/commit/5af886c57ff68ed8dfeae45802db40e355e128e3) | `` gtk-gnutella: use modern src arguments - tag & hash ``                                     |
| [`c3a76017`](https://github.com/NixOS/nixpkgs/commit/c3a760170570cf6d6e094adf687b672bcfcb1f4c) | `` typescript-go: 0-unstable-2026-05-12 -> 0-unstable-2026-05-20 ``                           |
| [`f4d58b57`](https://github.com/NixOS/nixpkgs/commit/f4d58b57ded3f0c6acab9a5f5364fb5386afe0c0) | `` gtk-gnutella: enable strictDeps && structured attrs ``                                     |
| [`a81eafb1`](https://github.com/NixOS/nixpkgs/commit/a81eafb1a60b93b76e8601de6a33dc0e992985a6) | `` deezer-desktop: 7.1.190 -> 7.1.200 ``                                                      |
| [`e66b6e71`](https://github.com/NixOS/nixpkgs/commit/e66b6e714ffb708ab7ce964fa6f2d2f7cafa2521) | `` rattler-build: 0.64.1 -> 0.65.0 ``                                                         |
| [`30cc1553`](https://github.com/NixOS/nixpkgs/commit/30cc15537724eada47c9dad28e27487247646051) | `` debase: fix darwin build ``                                                                |
| [`318301ae`](https://github.com/NixOS/nixpkgs/commit/318301ae42f2af1daea700f371b822e49e6d71a4) | `` spruce: 1.35.3 -> 1.35.4 ``                                                                |
| [`b6c4779d`](https://github.com/NixOS/nixpkgs/commit/b6c4779d26cb1edfeabe798307352e1a157b4b64) | `` clojure: 1.12.5.1638 -> 1.12.5.1645 ``                                                     |
| [`ed1a9424`](https://github.com/NixOS/nixpkgs/commit/ed1a9424505918beb4f16e175ab68c58c8b5096b) | `` phpunit: 13.1.8 -> 13.1.10 ``                                                              |
| [`12999e6d`](https://github.com/NixOS/nixpkgs/commit/12999e6de169741f42aa0cc279588f809e98888c) | `` copacetic: 0.14.0 -> 0.14.1 ``                                                             |
| [`4442964c`](https://github.com/NixOS/nixpkgs/commit/4442964c0c68587710256dd77a1c81197510bf57) | `` comma: modernize ``                                                                        |
| [`44e15166`](https://github.com/NixOS/nixpkgs/commit/44e15166e02c274c46a34424e85e23d60f724bfa) | `` nixos/system-environment: Export PATH to systemd transient environment ``                  |
| [`dee25834`](https://github.com/NixOS/nixpkgs/commit/dee25834873493155b4ed4526230be4b3c869465) | `` firefox-devedition-unwrapped: 150.0b7 -> 152.0b1 ``                                        |
| [`07158e09`](https://github.com/NixOS/nixpkgs/commit/07158e097e935e39544be77e8a2a152f713c35be) | `` talosctl: 1.13.0 -> 1.13.2 ``                                                              |
| [`5adeb511`](https://github.com/NixOS/nixpkgs/commit/5adeb511950f79ab1746d1fb4c69f25204f5f830) | `` buildbot{,-full,-ui,-worker,-plugins}: switch to pyproject ``                              |
| [`6af026c2`](https://github.com/NixOS/nixpkgs/commit/6af026c2bc70a8841ccb9429de8dd6ce1507b421) | `` nixos/mastodon: fix tootctl runtime path ``                                                |
| [`620d3d95`](https://github.com/NixOS/nixpkgs/commit/620d3d95fbfd48f8c567387fac3b0ca790de9069) | `` ledger-live-desktop: 4.2.2 -> 4.4.0 ``                                                     |
| [`7ab5bf6b`](https://github.com/NixOS/nixpkgs/commit/7ab5bf6ba1ff3035612929563697c459832df953) | `` turso: 0.4.0 -> 0.6.0 ``                                                                   |
| [`d61db496`](https://github.com/NixOS/nixpkgs/commit/d61db4960389b83dcd63bcf16e6108d7a2181a94) | `` python3Packages.inventree: 0.23.1 -> 0.23.2 ``                                             |
| [`01f96ff3`](https://github.com/NixOS/nixpkgs/commit/01f96ff3693ac7dac974699431de8ac4f8b23244) | `` Coq: disable CoqIDE for Coq < 8.10 ``                                                      |
| [`5bbb9bbd`](https://github.com/NixOS/nixpkgs/commit/5bbb9bbdc4174ef7dffffc702a95523a0b161b8a) | `` wakatime-cli: 2.11.3 -> 2.14.5 ``                                                          |
| [`e1cd29d4`](https://github.com/NixOS/nixpkgs/commit/e1cd29d4dcb1c0bf8b7e8619c85030ad5cfea456) | `` python3Packages.pysigma-backend-opensearch: 2.0.2 -> 2.0.3 ``                              |
| [`f40e6211`](https://github.com/NixOS/nixpkgs/commit/f40e621151769969dd61fe045dfa7bd39e7e34c2) | `` kiro: 0.12.184 -> 0.12.200 ``                                                              |
| [`b51f588a`](https://github.com/NixOS/nixpkgs/commit/b51f588a2add67e4e651dee53b64d69dd9747315) | `` terraform-providers.hashicorp_tls: 4.2.1 -> 4.3.0 ``                                       |
| [`f1d2366f`](https://github.com/NixOS/nixpkgs/commit/f1d2366fa1b0d3f307da23df1db8a5f6cc8abbf4) | `` python3Packages.asn1: 3.2.0 -> 3.3.0 ``                                                    |
| [`1f72e680`](https://github.com/NixOS/nixpkgs/commit/1f72e680f43887324281f86c9ef71342acf1b3f4) | `` flare-signal: 0.20.4 -> 0.20.5 ``                                                          |
| [`b52a522f`](https://github.com/NixOS/nixpkgs/commit/b52a522f361f71ab662d045c0e16296abf2251b9) | `` _1password-gui: 8.12.12 -> 8.12.21 ``                                                      |
| [`27ea2dec`](https://github.com/NixOS/nixpkgs/commit/27ea2dec9c13465584607a5882b1069717ee96e5) | `` godotPackages.export-template: 4.6.2-stable -> 4.6.3-stable ``                             |
| [`42a1f85b`](https://github.com/NixOS/nixpkgs/commit/42a1f85bd37782c985656fd474155433b0b2e8fa) | `` libretro.dosbox-pure: 0-unstable-2026-05-12 -> 0-unstable-2026-05-21 ``                    |
| [`5bfd15a4`](https://github.com/NixOS/nixpkgs/commit/5bfd15a4a6bd8bce4acf4b8ff78b29811ff3ceaa) | `` hmcl: 3.13.2 -> 3.14.1 ``                                                                  |
| [`2963b2f5`](https://github.com/NixOS/nixpkgs/commit/2963b2f593da161bb17cf9118e82124c62508fb8) | `` drupal: 11.3.9 -> 11.3.10 ``                                                               |
| [`f9c2c796`](https://github.com/NixOS/nixpkgs/commit/f9c2c79698896f60810d5164010b4b14e23bb9e4) | `` algia: 0.0.112 -> 0.0.120 ``                                                               |
| [`9f2e68fb`](https://github.com/NixOS/nixpkgs/commit/9f2e68fb431074e9e4086ef4e022248a73ecdb36) | `` floorp-bin-unwrapped: 12.14.0 -> 12.14.2 ``                                                |
| [`acfd9939`](https://github.com/NixOS/nixpkgs/commit/acfd99392809d6a3f25bf7fba55d997f9d9de91b) | `` gh-dash: 4.24.0 -> 4.24.1 ``                                                               |
| [`7207ddb6`](https://github.com/NixOS/nixpkgs/commit/7207ddb627d68c435e7a34d2eaa31171c1cd57f8) | `` claude-agent-acp: 0.33.1 -> 0.36.1 ``                                                      |
| [`3d8d6b63`](https://github.com/NixOS/nixpkgs/commit/3d8d6b63b46f4c3bdbe7b87e91d63cc1e99d3f26) | `` cloudflare-dynamic-dns: 4.4.4 -> 4.4.5 ``                                                  |
| [`f7d9577f`](https://github.com/NixOS/nixpkgs/commit/f7d9577f061d5744b2648ce18e0baa6c01ae28b3) | `` xapp-symbolic-icons: 1.0.9 -> 1.1.0 ``                                                     |
| [`351e935d`](https://github.com/NixOS/nixpkgs/commit/351e935de045cfab8815bb24051c868fc8217f9f) | `` victoriatraces: 0.8.2 -> 0.9.0 ``                                                          |
| [`74d868c4`](https://github.com/NixOS/nixpkgs/commit/74d868c4f9859bdb2a535697049b93b7eb1cb8bd) | `` vimPlugins.auto-dark-mode-nvim: init at 0-unstable-2026-03-29 ``                           |
| [`a994be2a`](https://github.com/NixOS/nixpkgs/commit/a994be2a2f639844fe8302214849dedbb0b7c44e) | `` vimPlugins.conflict-nvim: init at 0-unstable-2026-04-25 ``                                 |
| [`b1565ec8`](https://github.com/NixOS/nixpkgs/commit/b1565ec8fd8b64e14d301065fce7ede832d64969) | `` vimPlugins.nvim-dap-disasm: init at 0-unstable-2026-02-25 ``                               |
| [`1ab24c1d`](https://github.com/NixOS/nixpkgs/commit/1ab24c1d7cce86ad313f08bfabc942ef6874e3c0) | `` python3Packages.geodatasets: 2026.5.0 -> 2026.5.1 ``                                       |

*... and 2407 more commits (truncated)*