### PR TITLE
chore(flake/nixpkgs): `29916453` -> `64c08a7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779508470,
-        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "29916453413845e54a65b8a1cf996842300cd299",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`48412697`](https://github.com/NixOS/nixpkgs/commit/48412697e89d6e9bc7837eb420bc44b1e313244c) | `` netbird: 0.71.3 -> 0.71.4 ``                                                                      |
| [`5a37f4ec`](https://github.com/NixOS/nixpkgs/commit/5a37f4eca8c2c9e7004d4d1d44b881ba069908d1) | `` qui: 1.18.0 -> 1.19.0 ``                                                                          |
| [`de33a4ea`](https://github.com/NixOS/nixpkgs/commit/de33a4ea3785cca83ff5a5965c0f1652124338cf) | `` updatecli: 0.116.3 -> 0.117.0 ``                                                                  |
| [`2f50367e`](https://github.com/NixOS/nixpkgs/commit/2f50367ee5158d50a9b82ace2b197b4b08710af8) | `` apidog: 2.8.28 -> 2.8.30 ``                                                                       |
| [`ebc16523`](https://github.com/NixOS/nixpkgs/commit/ebc165237166e4f23e47a3539678b2b5a6d99ead) | `` xqilla: enable parallel building ``                                                               |
| [`ef379833`](https://github.com/NixOS/nixpkgs/commit/ef379833724d1aef27a05223f0f92e51a77a039a) | `` rtk: 0.40.0 -> 0.41.0 ``                                                                          |
| [`2d8469b0`](https://github.com/NixOS/nixpkgs/commit/2d8469b0101800134c1ceeea7c5777927dd51deb) | `` home-assistant-custom-components.closest_intent: init at 0.1.0 ``                                 |
| [`2fa56d6e`](https://github.com/NixOS/nixpkgs/commit/2fa56d6e1ea9d3220237c80c55a5591cfeac195b) | `` streamcontroller: 1.5.0-beta.13 -> 1.5.0-beta.14 ``                                               |
| [`227390cd`](https://github.com/NixOS/nixpkgs/commit/227390cd4794adf1932ab9f4c7014f2a8ef0364f) | `` home-assistant-custom-components.local_openai: init at 1.6.0 ``                                   |
| [`7bfd4f2a`](https://github.com/NixOS/nixpkgs/commit/7bfd4f2adfe8e5f048930766d159948df19c099d) | `` home-assistant-custom-components.mypyllant: 0.9.12 -> 0.9.13 ``                                   |
| [`297e7591`](https://github.com/NixOS/nixpkgs/commit/297e75917e9c0e1f0e9fc8f606c9c5585ab32a70) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.332 -> 0.13.333 ``         |
| [`466a800c`](https://github.com/NixOS/nixpkgs/commit/466a800c2b71a1e11d153e1682a03f01dfbf03dc) | `` python314Packages.homeassistant-stubs: 2026.5.3 -> 2026.5.4 ``                                    |
| [`a7ced727`](https://github.com/NixOS/nixpkgs/commit/a7ced7272ec8b3f3850e1a45197fb787b8c2611c) | `` home-assistant-custom-components.yandex-station: 3.20.3 -> 3.21.1 ``                              |
| [`bb0fa7f6`](https://github.com/NixOS/nixpkgs/commit/bb0fa7f67f47831d0aca96d9c670743f0d11bf84) | `` home-assistant-custom-components.oref_alert: 6.18.2 -> 6.18.3 ``                                  |
| [`b37108be`](https://github.com/NixOS/nixpkgs/commit/b37108be35826d7b071002e4b6188bb0b3dd7207) | `` home-assistant-custom-components.garmin_connect: 3.0.7 -> 3.0.8 ``                                |
| [`6bbd96dd`](https://github.com/NixOS/nixpkgs/commit/6bbd96dd7b73879c18b048b4e34f9bcda0dccf46) | `` python3Packages.ha-garmin: 0.1.22 -> 0.1.23 ``                                                    |
| [`32cc9809`](https://github.com/NixOS/nixpkgs/commit/32cc9809bf4bbefbb280a50eae0268d1032a438c) | `` home-assistant-custom-components.entity-notes: 3.3.4 -> 3.3.10 ``                                 |
| [`95c37c86`](https://github.com/NixOS/nixpkgs/commit/95c37c86b21d562286bf330197390284dfa29d83) | `` home-assistant-custom-components.alarmo: 1.10.17 -> 1.10.18 ``                                    |
| [`31ca7d37`](https://github.com/NixOS/nixpkgs/commit/31ca7d375344e62df00b7160aa8792097d59c8cd) | `` home-assistant: 2026.5.3 -> 2026.5.4 ``                                                           |
| [`e18c3ff6`](https://github.com/NixOS/nixpkgs/commit/e18c3ff6bfe29d385cc0065cdf3cd4381b849935) | `` python3Packages.wled: 0.22.0 -> 0.23.0 ``                                                         |
| [`b73acd96`](https://github.com/NixOS/nixpkgs/commit/b73acd96949ccbc124721c6aa74d71e2cb3cf7d4) | `` python3Packages.python-backoff: init at 2.3.1 ``                                                  |
| [`e875e2a1`](https://github.com/NixOS/nixpkgs/commit/e875e2a1f3951b5b2cda249bf7657ddb3450987c) | `` python3Packages.renault-api: 0.5.8 -> 0.5.10 ``                                                   |
| [`e956b9e3`](https://github.com/NixOS/nixpkgs/commit/e956b9e3b1769631f98ae6d0d51a9143402307f9) | `` python3Packages.python-roborock: 5.5.1 -> 5.12.0 ``                                               |
| [`3821e9e8`](https://github.com/NixOS/nixpkgs/commit/3821e9e8bc1cace1569c0f3015393536bbd62484) | `` python3Packages.aiolyric: 2.1.0 -> 2.1.1 ``                                                       |
| [`71fa9158`](https://github.com/NixOS/nixpkgs/commit/71fa9158c78ca9348ec8f6bee7dbae7826ca4417) | `` python3Packages.pycyphal: disable doctests broken by asyncio task leaks on python 3.14 ``         |
| [`2622050d`](https://github.com/NixOS/nixpkgs/commit/2622050d916555458a7c0c352aea82060a9fcc8e) | `` Revert "mdbook: 0.5.2 -> 0.5.3" ``                                                                |
| [`69004d6c`](https://github.com/NixOS/nixpkgs/commit/69004d6c9b80163a6676cefc2b163916fcc818a2) | `` qwen-code: 0.15.11 -> 0.16.0 ``                                                                   |
| [`452f7ac7`](https://github.com/NixOS/nixpkgs/commit/452f7ac753cff5a9ca2d685f84385c5d1296b00c) | `` python3Packages.sigrok: fix build with swig 4.4 ``                                                |
| [`754c1c76`](https://github.com/NixOS/nixpkgs/commit/754c1c760e7f0212965f0f8f98b841bdb7d18425) | `` execline.manpages: 2.9.8.1.3 -> 2.9.9.1.1 ``                                                      |
| [`8b48b20a`](https://github.com/NixOS/nixpkgs/commit/8b48b20abdd87d5b6e2093c61099f5399c3449e4) | `` tipidee: 0.0.7.1 -> 0.0.7.2 ``                                                                    |
| [`7875de5f`](https://github.com/NixOS/nixpkgs/commit/7875de5f5d6234bcd5fca63ce325d9b7b766b8bb) | `` mdevd: 0.1.8.1 -> 0.1.8.2 ``                                                                      |
| [`4ba25795`](https://github.com/NixOS/nixpkgs/commit/4ba2579545b1ed4908c0bf9f86a187103478f614) | `` s6-networking: 2.7.2.1 -> 2.8.0.0 ``                                                              |
| [`1849d5f6`](https://github.com/NixOS/nixpkgs/commit/1849d5f660994a020e085b4efea5fbad9edf69d3) | `` s6-dns: 2.4.1.1 -> 2.4.1.2 ``                                                                     |
| [`cc306432`](https://github.com/NixOS/nixpkgs/commit/cc306432861192940d12ea08d97aced089060dfc) | `` s6-linux-utils: 2.6.4.0 -> 2.6.4.1 ``                                                             |
| [`e5c136b8`](https://github.com/NixOS/nixpkgs/commit/e5c136b862accbb3b0ca243ac5d0d0b45c782ffc) | `` s6-portable-utils: 2.3.1.1 -> 2.3.1.2 ``                                                          |
| [`514f6d2c`](https://github.com/NixOS/nixpkgs/commit/514f6d2cf2a9992b48d2eab66ed2c1ef55270b22) | `` s6-linux-init: 1.2.0.0 -> 1.2.0.1 ``                                                              |
| [`84dfce20`](https://github.com/NixOS/nixpkgs/commit/84dfce20a052c36abf5210ae1a02cda30fafcc8f) | `` s6-rc: 0.6.0.0 -> 0.6.1.1 ``                                                                      |
| [`baeb831e`](https://github.com/NixOS/nixpkgs/commit/baeb831e165a8a910ee8cde3223d1a500ebd0679) | `` s6: 2.14.0.1 -> 2.15.0.0 ``                                                                       |
| [`d7fa5fca`](https://github.com/NixOS/nixpkgs/commit/d7fa5fca04bb55c1bdcbc258d3440dec378b5704) | `` execline: 2.9.8.1 -> 2.9.9.1 ``                                                                   |
| [`0938eafb`](https://github.com/NixOS/nixpkgs/commit/0938eafb082a9f14cd473a6095c5adfc0f3a8ac7) | `` utmps: 0.1.3.2 -> 0.1.3.3 ``                                                                      |
| [`a357cebe`](https://github.com/NixOS/nixpkgs/commit/a357cebeccabf5cd87389cc341898a88596de50a) | `` nsss: 0.2.1.1 -> 0.2.1.2 ``                                                                       |
| [`b4ce6d1a`](https://github.com/NixOS/nixpkgs/commit/b4ce6d1a90ec81bf6c744630c6eb260d54421362) | `` skalibs: 2.14.5.1 -> 2.15.0.0 ``                                                                  |
| [`d12f36bf`](https://github.com/NixOS/nixpkgs/commit/d12f36bf2189015c0874459ae42f4c1a1f1d51ea) | `` pihole-web: 6.4.1 -> 6.5 ``                                                                       |
| [`00073245`](https://github.com/NixOS/nixpkgs/commit/00073245bc1d9160b1f1b2abde4028c723e9ff4f) | `` linux_6_6: 6.6.140 -> 6.6.141 ``                                                                  |
| [`802bd350`](https://github.com/NixOS/nixpkgs/commit/802bd3500a12257fae31787c268fb37da2c45fed) | `` linux_6_12: 6.12.90 -> 6.12.91 ``                                                                 |
| [`8bd16a68`](https://github.com/NixOS/nixpkgs/commit/8bd16a6891b63143c89e67fec71d39be32dfcc7e) | `` linux_6_18: 6.18.32 -> 6.18.33 ``                                                                 |
| [`60084bc7`](https://github.com/NixOS/nixpkgs/commit/60084bc78f912b0d8ad2eb440cdc8d2562756e05) | `` linux_7_0: 7.0.9 -> 7.0.10 ``                                                                     |
| [`aac1bea2`](https://github.com/NixOS/nixpkgs/commit/aac1bea2f5cec90280d1978aa5f7f726b0f6c40c) | `` resterm: 0.39.3 -> 0.39.5 ``                                                                      |
| [`48412697`](https://github.com/NixOS/nixpkgs/commit/48412697e89d6e9bc7837eb420bc44b1e313244c) | `` netbird: 0.71.3 -> 0.71.4 ``                                                                      |
| [`5a37f4ec`](https://github.com/NixOS/nixpkgs/commit/5a37f4eca8c2c9e7004d4d1d44b881ba069908d1) | `` qui: 1.18.0 -> 1.19.0 ``                                                                          |
| [`de33a4ea`](https://github.com/NixOS/nixpkgs/commit/de33a4ea3785cca83ff5a5965c0f1652124338cf) | `` updatecli: 0.116.3 -> 0.117.0 ``                                                                  |
| [`2f50367e`](https://github.com/NixOS/nixpkgs/commit/2f50367ee5158d50a9b82ace2b197b4b08710af8) | `` apidog: 2.8.28 -> 2.8.30 ``                                                                       |
| [`ebc16523`](https://github.com/NixOS/nixpkgs/commit/ebc165237166e4f23e47a3539678b2b5a6d99ead) | `` xqilla: enable parallel building ``                                                               |
| [`ef379833`](https://github.com/NixOS/nixpkgs/commit/ef379833724d1aef27a05223f0f92e51a77a039a) | `` rtk: 0.40.0 -> 0.41.0 ``                                                                          |
| [`2d8469b0`](https://github.com/NixOS/nixpkgs/commit/2d8469b0101800134c1ceeea7c5777927dd51deb) | `` home-assistant-custom-components.closest_intent: init at 0.1.0 ``                                 |
| [`2fa56d6e`](https://github.com/NixOS/nixpkgs/commit/2fa56d6e1ea9d3220237c80c55a5591cfeac195b) | `` streamcontroller: 1.5.0-beta.13 -> 1.5.0-beta.14 ``                                               |
| [`227390cd`](https://github.com/NixOS/nixpkgs/commit/227390cd4794adf1932ab9f4c7014f2a8ef0364f) | `` home-assistant-custom-components.local_openai: init at 1.6.0 ``                                   |
| [`7bfd4f2a`](https://github.com/NixOS/nixpkgs/commit/7bfd4f2adfe8e5f048930766d159948df19c099d) | `` home-assistant-custom-components.mypyllant: 0.9.12 -> 0.9.13 ``                                   |
| [`297e7591`](https://github.com/NixOS/nixpkgs/commit/297e75917e9c0e1f0e9fc8f606c9c5585ab32a70) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.332 -> 0.13.333 ``         |
| [`466a800c`](https://github.com/NixOS/nixpkgs/commit/466a800c2b71a1e11d153e1682a03f01dfbf03dc) | `` python314Packages.homeassistant-stubs: 2026.5.3 -> 2026.5.4 ``                                    |
| [`a7ced727`](https://github.com/NixOS/nixpkgs/commit/a7ced7272ec8b3f3850e1a45197fb787b8c2611c) | `` home-assistant-custom-components.yandex-station: 3.20.3 -> 3.21.1 ``                              |
| [`bb0fa7f6`](https://github.com/NixOS/nixpkgs/commit/bb0fa7f67f47831d0aca96d9c670743f0d11bf84) | `` home-assistant-custom-components.oref_alert: 6.18.2 -> 6.18.3 ``                                  |
| [`b37108be`](https://github.com/NixOS/nixpkgs/commit/b37108be35826d7b071002e4b6188bb0b3dd7207) | `` home-assistant-custom-components.garmin_connect: 3.0.7 -> 3.0.8 ``                                |
| [`6bbd96dd`](https://github.com/NixOS/nixpkgs/commit/6bbd96dd7b73879c18b048b4e34f9bcda0dccf46) | `` python3Packages.ha-garmin: 0.1.22 -> 0.1.23 ``                                                    |
| [`32cc9809`](https://github.com/NixOS/nixpkgs/commit/32cc9809bf4bbefbb280a50eae0268d1032a438c) | `` home-assistant-custom-components.entity-notes: 3.3.4 -> 3.3.10 ``                                 |
| [`95c37c86`](https://github.com/NixOS/nixpkgs/commit/95c37c86b21d562286bf330197390284dfa29d83) | `` home-assistant-custom-components.alarmo: 1.10.17 -> 1.10.18 ``                                    |
| [`31ca7d37`](https://github.com/NixOS/nixpkgs/commit/31ca7d375344e62df00b7160aa8792097d59c8cd) | `` home-assistant: 2026.5.3 -> 2026.5.4 ``                                                           |
| [`e18c3ff6`](https://github.com/NixOS/nixpkgs/commit/e18c3ff6bfe29d385cc0065cdf3cd4381b849935) | `` python3Packages.wled: 0.22.0 -> 0.23.0 ``                                                         |
| [`b73acd96`](https://github.com/NixOS/nixpkgs/commit/b73acd96949ccbc124721c6aa74d71e2cb3cf7d4) | `` python3Packages.python-backoff: init at 2.3.1 ``                                                  |
| [`e875e2a1`](https://github.com/NixOS/nixpkgs/commit/e875e2a1f3951b5b2cda249bf7657ddb3450987c) | `` python3Packages.renault-api: 0.5.8 -> 0.5.10 ``                                                   |
| [`e956b9e3`](https://github.com/NixOS/nixpkgs/commit/e956b9e3b1769631f98ae6d0d51a9143402307f9) | `` python3Packages.python-roborock: 5.5.1 -> 5.12.0 ``                                               |
| [`3821e9e8`](https://github.com/NixOS/nixpkgs/commit/3821e9e8bc1cace1569c0f3015393536bbd62484) | `` python3Packages.aiolyric: 2.1.0 -> 2.1.1 ``                                                       |
| [`71fa9158`](https://github.com/NixOS/nixpkgs/commit/71fa9158c78ca9348ec8f6bee7dbae7826ca4417) | `` python3Packages.pycyphal: disable doctests broken by asyncio task leaks on python 3.14 ``         |
| [`2622050d`](https://github.com/NixOS/nixpkgs/commit/2622050d916555458a7c0c352aea82060a9fcc8e) | `` Revert "mdbook: 0.5.2 -> 0.5.3" ``                                                                |
| [`69004d6c`](https://github.com/NixOS/nixpkgs/commit/69004d6c9b80163a6676cefc2b163916fcc818a2) | `` qwen-code: 0.15.11 -> 0.16.0 ``                                                                   |
| [`452f7ac7`](https://github.com/NixOS/nixpkgs/commit/452f7ac753cff5a9ca2d685f84385c5d1296b00c) | `` python3Packages.sigrok: fix build with swig 4.4 ``                                                |
| [`754c1c76`](https://github.com/NixOS/nixpkgs/commit/754c1c760e7f0212965f0f8f98b841bdb7d18425) | `` execline.manpages: 2.9.8.1.3 -> 2.9.9.1.1 ``                                                      |
| [`8b48b20a`](https://github.com/NixOS/nixpkgs/commit/8b48b20abdd87d5b6e2093c61099f5399c3449e4) | `` tipidee: 0.0.7.1 -> 0.0.7.2 ``                                                                    |
| [`7875de5f`](https://github.com/NixOS/nixpkgs/commit/7875de5f5d6234bcd5fca63ce325d9b7b766b8bb) | `` mdevd: 0.1.8.1 -> 0.1.8.2 ``                                                                      |
| [`4ba25795`](https://github.com/NixOS/nixpkgs/commit/4ba2579545b1ed4908c0bf9f86a187103478f614) | `` s6-networking: 2.7.2.1 -> 2.8.0.0 ``                                                              |
| [`1849d5f6`](https://github.com/NixOS/nixpkgs/commit/1849d5f660994a020e085b4efea5fbad9edf69d3) | `` s6-dns: 2.4.1.1 -> 2.4.1.2 ``                                                                     |
| [`cc306432`](https://github.com/NixOS/nixpkgs/commit/cc306432861192940d12ea08d97aced089060dfc) | `` s6-linux-utils: 2.6.4.0 -> 2.6.4.1 ``                                                             |
| [`e5c136b8`](https://github.com/NixOS/nixpkgs/commit/e5c136b862accbb3b0ca243ac5d0d0b45c782ffc) | `` s6-portable-utils: 2.3.1.1 -> 2.3.1.2 ``                                                          |
| [`514f6d2c`](https://github.com/NixOS/nixpkgs/commit/514f6d2cf2a9992b48d2eab66ed2c1ef55270b22) | `` s6-linux-init: 1.2.0.0 -> 1.2.0.1 ``                                                              |
| [`84dfce20`](https://github.com/NixOS/nixpkgs/commit/84dfce20a052c36abf5210ae1a02cda30fafcc8f) | `` s6-rc: 0.6.0.0 -> 0.6.1.1 ``                                                                      |
| [`baeb831e`](https://github.com/NixOS/nixpkgs/commit/baeb831e165a8a910ee8cde3223d1a500ebd0679) | `` s6: 2.14.0.1 -> 2.15.0.0 ``                                                                       |
| [`d7fa5fca`](https://github.com/NixOS/nixpkgs/commit/d7fa5fca04bb55c1bdcbc258d3440dec378b5704) | `` execline: 2.9.8.1 -> 2.9.9.1 ``                                                                   |
| [`0938eafb`](https://github.com/NixOS/nixpkgs/commit/0938eafb082a9f14cd473a6095c5adfc0f3a8ac7) | `` utmps: 0.1.3.2 -> 0.1.3.3 ``                                                                      |
| [`a357cebe`](https://github.com/NixOS/nixpkgs/commit/a357cebeccabf5cd87389cc341898a88596de50a) | `` nsss: 0.2.1.1 -> 0.2.1.2 ``                                                                       |
| [`b4ce6d1a`](https://github.com/NixOS/nixpkgs/commit/b4ce6d1a90ec81bf6c744630c6eb260d54421362) | `` skalibs: 2.14.5.1 -> 2.15.0.0 ``                                                                  |
| [`d12f36bf`](https://github.com/NixOS/nixpkgs/commit/d12f36bf2189015c0874459ae42f4c1a1f1d51ea) | `` pihole-web: 6.4.1 -> 6.5 ``                                                                       |
| [`00073245`](https://github.com/NixOS/nixpkgs/commit/00073245bc1d9160b1f1b2abde4028c723e9ff4f) | `` linux_6_6: 6.6.140 -> 6.6.141 ``                                                                  |
| [`802bd350`](https://github.com/NixOS/nixpkgs/commit/802bd3500a12257fae31787c268fb37da2c45fed) | `` linux_6_12: 6.12.90 -> 6.12.91 ``                                                                 |
| [`8bd16a68`](https://github.com/NixOS/nixpkgs/commit/8bd16a6891b63143c89e67fec71d39be32dfcc7e) | `` linux_6_18: 6.18.32 -> 6.18.33 ``                                                                 |
| [`60084bc7`](https://github.com/NixOS/nixpkgs/commit/60084bc78f912b0d8ad2eb440cdc8d2562756e05) | `` linux_7_0: 7.0.9 -> 7.0.10 ``                                                                     |
| [`aac1bea2`](https://github.com/NixOS/nixpkgs/commit/aac1bea2f5cec90280d1978aa5f7f726b0f6c40c) | `` resterm: 0.39.3 -> 0.39.5 ``                                                                      |
| [`1d6a5191`](https://github.com/NixOS/nixpkgs/commit/1d6a51916f0db54362607477e9d678abac5cf203) | `` python3Packages.cadwyn: 6.2.0 -> 6.2.2 ``                                                         |
| [`e01d6575`](https://github.com/NixOS/nixpkgs/commit/e01d65753bf7db6f1cd38736ce5f22a90c180916) | `` mcdreforged: cleanup ``                                                                           |
| [`5cb52e21`](https://github.com/NixOS/nixpkgs/commit/5cb52e21868458115f297228f8edbdc9129373bf) | `` mcdreforged: fix build ``                                                                         |
| [`82ed78a9`](https://github.com/NixOS/nixpkgs/commit/82ed78a9ee81eada31b619ebcdbb248daa123b9a) | `` nixos/gdm: add warning for Pulseaudio + gdm ``                                                    |
| [`9d1626ac`](https://github.com/NixOS/nixpkgs/commit/9d1626acb2c16c60b700548f689240d6918b06ef) | `` solanum: 0-unstable-2026-05-13 -> 0-unstable-2026-05-23 ``                                        |
| [`2b9f291a`](https://github.com/NixOS/nixpkgs/commit/2b9f291a4d18deea98038f71db622de7b4b94d69) | `` atril: 1.28.4 -> 1.28.5 ``                                                                        |
| [`8fb72822`](https://github.com/NixOS/nixpkgs/commit/8fb728225955b8f0afbd41da634bdc8bdaaf7997) | `` hot-resize: 0.1.6 -> 0.1.7 ``                                                                     |
| [`bde39b04`](https://github.com/NixOS/nixpkgs/commit/bde39b04eda5984de5a6d0df2890a7ac80ba9c6f) | `` python3Packages.aioamazondevices: 13.5.0 -> 13.7.2 ``                                             |
| [`f4ed0add`](https://github.com/NixOS/nixpkgs/commit/f4ed0add00aaaed1d706e7681399c264b3c19e61) | `` hyprlandPlugins.hypr-darkwindow: 0.54.3 -> 0.55.2 ``                                              |
| [`47e19f5f`](https://github.com/NixOS/nixpkgs/commit/47e19f5f91a9d3eebd7a6e5f117fba494e56a8c1) | `` nixos/containers: fix default gateway with privateNetwork ``                                      |
| [`2c48a021`](https://github.com/NixOS/nixpkgs/commit/2c48a021b24208c946db0b17ffb9cce004d3fcc1) | `` better-commits: 1.23.0 -> 1.23.1 ``                                                               |
| [`51552f84`](https://github.com/NixOS/nixpkgs/commit/51552f84ca8d2fa2cc74fabd86ba299a309a12c8) | `` python3Packages.nextcord: 3.1.1 -> 3.2.0 ``                                                       |
| [`7db9ff04`](https://github.com/NixOS/nixpkgs/commit/7db9ff04d54b01da28e3e71f53b1e9ae2e98aff9) | `` pi-coding-agent: 0.75.3 -> 0.75.4 ``                                                              |
| [`234afb7b`](https://github.com/NixOS/nixpkgs/commit/234afb7b18de2d088c2ad536bd6e94cb189ecc52) | `` hooky: fix build with kdl-hs 1.1 ``                                                               |
| [`9c081c46`](https://github.com/NixOS/nixpkgs/commit/9c081c4653f7e40dd30ba88fa898891100223c36) | `` atlauncher: fix aarch64-linux build ``                                                            |
| [`0a4b21c7`](https://github.com/NixOS/nixpkgs/commit/0a4b21c747c259de727cec2543ef412c18c026ad) | `` bark-server: 2.3.4 -> 2.3.5 ``                                                                    |
| [`bb617e6f`](https://github.com/NixOS/nixpkgs/commit/bb617e6fdf7ec98e9a7671dcec146f183fbd929f) | `` labwc-tweaks-gtk: 0-unstable-2026-05-09 -> 0-unstable-2026-05-22 ``                               |
| [`d65495fe`](https://github.com/NixOS/nixpkgs/commit/d65495fe777d7e249b973568590615d6a2124bbe) | `` jetbrains.webstorm: 2026.1.1 -> 2026.1.2 ``                                                       |
| [`308c3c35`](https://github.com/NixOS/nixpkgs/commit/308c3c352cdbda17ab08b750886d3b5895018a05) | `` nginx: 1.30.1 -> 1.30.2 ``                                                                        |
| [`a56e5e28`](https://github.com/NixOS/nixpkgs/commit/a56e5e28a549a7d217ae3901a4cecfc2813d0f20) | `` python3Packages.jsonschema-rs: set __darwinAllowLocalNetworking ``                                |
| [`f669e5b8`](https://github.com/NixOS/nixpkgs/commit/f669e5b809cd9a4315c1b80c10a77a8f6500e3cb) | `` android-studio-for-platform: stable 2024.2.2.13 -> 2025.3.2.6, canary 2024.3.1.9 -> 2026.1.2.1 `` |
| [`be3620d1`](https://github.com/NixOS/nixpkgs/commit/be3620d19fe11673f84ceb67e6fefda36a161049) | `` open-webui: remove --legacy-peer-deps ``                                                          |
| [`82eaf694`](https://github.com/NixOS/nixpkgs/commit/82eaf69469a5fb2e86993eba825d1c8a8410eb45) | `` deja: 0.2.5 -> 0.2.6 ``                                                                           |
| [`ae8284b8`](https://github.com/NixOS/nixpkgs/commit/ae8284b80c49dea96d21b134081506ec6b4139a8) | `` wcslib: 8.7 -> 8.8 ``                                                                             |
| [`6b9d6878`](https://github.com/NixOS/nixpkgs/commit/6b9d6878d062b388770b9c43e9ba16c3113d451a) | `` libretro.mupen64plus: 0-unstable-2026-05-12 -> 0-unstable-2026-05-20 ``                           |
| [`97096dae`](https://github.com/NixOS/nixpkgs/commit/97096daea4d8a24103b30cdc77e0763ba4137899) | `` typesetter: 0.12.6 -> 0.13.1 ``                                                                   |
| [`98817ee9`](https://github.com/NixOS/nixpkgs/commit/98817ee929bddb5203c51e847a67937b272c55f1) | `` kiesel: init at 0.2.0 ``                                                                          |
| [`9a763ad0`](https://github.com/NixOS/nixpkgs/commit/9a763ad07bb1ec49cb4eff828bc31cdd59cb3dd6) | `` postgrest: 14.11 -> 14.12 ``                                                                      |
| [`0b00dcb6`](https://github.com/NixOS/nixpkgs/commit/0b00dcb6dfb36210684f519c3d336c2f33fe0d5a) | `` uv: 0.11.15 -> 0.11.16 ``                                                                         |
| [`79ca1dd2`](https://github.com/NixOS/nixpkgs/commit/79ca1dd2b541795da8cdabac5d7df6fa87ab42a2) | `` wgsl-analyzer: 2026-03-13 -> 2026-04-26 ``                                                        |
| [`5bc550b3`](https://github.com/NixOS/nixpkgs/commit/5bc550b3c13831f9d78420d6437fef3c3859e36e) | `` nginxMainline: 1.31.0 -> 1.31.1 ``                                                                |
| [`48f9d065`](https://github.com/NixOS/nixpkgs/commit/48f9d0652e55892b6e10094ecafebde01baf481b) | `` owi: 0.2-unstable-2026-05-05 -> 0.2-unstable-2026-05-22 ``                                        |
| [`79d21004`](https://github.com/NixOS/nixpkgs/commit/79d21004a23e2927ea8b479da3128b5bf9e8ba91) | `` mirrord: 3.210.0 -> 3.211.0 ``                                                                    |
| [`98086d4d`](https://github.com/NixOS/nixpkgs/commit/98086d4dcfbcb53afb31b474c5c2c510451456b8) | `` nwg-panel: 0.10.13 -> 0.10.15 ``                                                                  |
| [`d2ea1ace`](https://github.com/NixOS/nixpkgs/commit/d2ea1ace635737c4d4efe66ffe7a1d90507ae5c5) | `` starlark: 0-unstable-2026-03-26 -> 0-unstable-2026-05-22 ``                                       |
| [`1e4eae94`](https://github.com/NixOS/nixpkgs/commit/1e4eae9424e611d5eb045b48c4cc465db0b16056) | `` debian-devscripts: vendor patches ``                                                              |
| [`598efa9f`](https://github.com/NixOS/nixpkgs/commit/598efa9f666472319d3569cc71768163681cd683) | `` rerun: 0.32.1 -> 0.32.2 ``                                                                        |
| [`c268f3ff`](https://github.com/NixOS/nixpkgs/commit/c268f3ff1ebc84a21ce98d0fd12aee2332b0a2f7) | `` fotema: fix build with ffmpeg 8.1 ``                                                              |
| [`b70649e9`](https://github.com/NixOS/nixpkgs/commit/b70649e94928253e40bcf3f6b553c2e9a7105843) | `` macopix: fix compilation with -std=gnu99 ``                                                       |
| [`aebdcfe3`](https://github.com/NixOS/nixpkgs/commit/aebdcfe36574bf0a31c915641d02152eee930915) | `` xqilla: fix src hash ``                                                                           |
| [`c103da6a`](https://github.com/NixOS/nixpkgs/commit/c103da6a19c623e6e5c8c791d8012c29855bb802) | `` ci: add nixosTests.simple-container ``                                                            |
| [`70558450`](https://github.com/NixOS/nixpkgs/commit/70558450409e91a92d4a50b6fb2676cf0305cd5c) | `` nixos/release{,-small}: add nixosTests.simple-container ``                                        |
| [`cdc68a26`](https://github.com/NixOS/nixpkgs/commit/cdc68a268ce96acf39abf37c360ab1a58d6cdb17) | `` nixos/tests: add simple-container ``                                                              |
| [`244b7004`](https://github.com/NixOS/nixpkgs/commit/244b70040392ab04d0e570d984e1b654a8f58d77) | `` nixosTests.simple-vm: rename from nixosTests.simple ``                                            |
| [`0ea2bc77`](https://github.com/NixOS/nixpkgs/commit/0ea2bc77fd43d06da284dd802bb30603a0bf91b6) | `` python3Packages.jsonschema-rs: 0.39.0 -> 0.46.5 ``                                                |
| [`5d6beea8`](https://github.com/NixOS/nixpkgs/commit/5d6beea86ec1d9969ddb2408ffa7919a2d3fa7c9) | `` python3Packages.snakemake-interface-logger-plugins: 2.0.1 -> 2.1.0 ``                             |
| [`8fdd30ac`](https://github.com/NixOS/nixpkgs/commit/8fdd30ac73e195ac1013d83a0c823ef209c86217) | `` snakemake: 9.16.3 -> 9.21.0 ``                                                                    |
| [`669f01f0`](https://github.com/NixOS/nixpkgs/commit/669f01f035e675f02530080d98f95606b32a418f) | `` python3Packages.snakemake-interface-logger-plugins: enable tests ``                               |
| [`2e7ebe35`](https://github.com/NixOS/nixpkgs/commit/2e7ebe3578cc9fdc24e7b6377ebb081c56724653) | `` python3Packages.snakemake-logger-plugin-rich: init at 0.4.1 ``                                    |
| [`d4eedeb6`](https://github.com/NixOS/nixpkgs/commit/d4eedeb694b5ba8a11244e07a6594a81f76ee6d8) | `` python3Packages.snakemake-storage-plugin-fs: cleanup ``                                           |
| [`12768496`](https://github.com/NixOS/nixpkgs/commit/1276849637da8a938d6d389f6cd628a85bec11fc) | `` python3Packages.snakemake-interface-report-plugins: cleanup ``                                    |
| [`f92b3f5b`](https://github.com/NixOS/nixpkgs/commit/f92b3f5b26b47cef096ce81d8149eb935461a2dd) | `` python3Packages.snakemake-interface-logger-plugins: cleanup ``                                    |
| [`0b4982f4`](https://github.com/NixOS/nixpkgs/commit/0b4982f44a58838f6af4f6b3462513c74fa9f983) | `` python3Packages.snakemake-interface-executor-plugins: cleanup ``                                  |
| [`90d358c2`](https://github.com/NixOS/nixpkgs/commit/90d358c2c5d718a94aca5b90da520e898fd34776) | `` python3Packages.snakemake-interface-common: cleanup ``                                            |
| [`e7dbc2e4`](https://github.com/NixOS/nixpkgs/commit/e7dbc2e41d6ad5903a52042a698a470865cc504c) | `` python3Packages.snakemake-storage-plugin-xrootd: 1.0.0 -> 1.1.0 ``                                |