### PR TITLE
fix: TCP keepalive survives reconnect; dependency cleanup; version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -151,15 +151,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -169,9 +169,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -789,7 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -889,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "matchers"
@@ -959,15 +959,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1181,7 +1181,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1300,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1331,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1375,9 +1375,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1423,7 +1423,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -1746,9 +1746,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -1804,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1817,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1827,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1840,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -1875,7 +1875,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2121,7 +2121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
@@ -2159,9 +2159,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
- "zmq",
 ]
 
 [[package]]
@@ -35,9 +34,6 @@ version = "0.2.0"
 dependencies = [
  "acars_config",
  "acars_connection_manager",
- "serde",
- "serde_json",
- "socket2",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ categories = ["command-line-utilities", "network-programming"]
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tokio = { version = "1.52.2", features = ["full", "tracing"] }
-serde_json = "1.0.149"
+serde_json = "1.0.150"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 sdre-stubborn-io = "0.7.1"
-socket2 = "0.6.3"
+socket2 = "0.6.4"
 tokio-util = { version = "0.7.18", features = ["full"] }
 tokio-stream = "0.1.18"
 futures = "0.3.32"
@@ -37,25 +37,25 @@ acars_vdlm2_parser = { git = "https://github.com/jcdeimos/acars_vdlm2_parser", v
 hickory-resolver = "0.26.1"
 
 [workspace.lints.rust]
-unsafe_code      = "forbid"
+unsafe_code = "forbid"
 rust_2018_idioms = { level = "warn", priority = -1 }
-unreachable_pub  = "warn"
+unreachable_pub = "warn"
 # missing_docs deferred until a dedicated docs pass; the existing codebase has
 # essentially no rustdoc and surfacing hundreds of warnings here would drown
 # the signal from the lints below.
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }
-nursery  = { level = "warn", priority = -1 }
-cargo    = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
 # explicit opt-outs that are noisy in this codebase
 module_name_repetitions = "allow"
-missing_errors_doc      = "allow"
-missing_panics_doc      = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
 # transitive deps (tokio, mio, zmq-sys, etc.) pull in multiple versions
 multiple_crate_versions = "allow"
 # `too_many_lines` is allowed at the workspace level, but only on a
 # case-by-case basis where splitting the function would harm readability
 # (e.g. linear top-level orchestration in `main`). All other lints must
 # be fixed, not silenced.
-too_many_lines          = "allow"
+too_many_lines = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ categories = ["command-line-utilities", "network-programming"]
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tokio = { version = "1.52.2", features = ["full", "tracing"] }
-serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 sdre-stubborn-io = "0.7.1"
@@ -33,10 +32,8 @@ socket2 = "0.6.3"
 tokio-util = { version = "0.7.18", features = ["full"] }
 tokio-stream = "0.1.18"
 futures = "0.3.32"
-zmq = "0.10.0"
 tmq = "0.5.0"
 acars_vdlm2_parser = { git = "https://github.com/jcdeimos/acars_vdlm2_parser", version = "0.4.0" }
-acars_config = { path = "../acars_config" }
 hickory-resolver = "0.26.1"
 
 [workspace.lints.rust]

--- a/rust/bin/acars_router/Cargo.toml
+++ b/rust/bin/acars_router/Cargo.toml
@@ -20,9 +20,6 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-socket2.workspace = true
 
 [lints]
 workspace = true

--- a/rust/libraries/acars_connection_manager/Cargo.toml
+++ b/rust/libraries/acars_connection_manager/Cargo.toml
@@ -24,7 +24,6 @@ tokio.workspace = true
 tokio-util.workspace = true
 tokio-stream.workspace = true
 futures.workspace = true
-zmq.workspace = true
 tmq.workspace = true
 socket2.workspace = true
 hickory-resolver.workspace = true

--- a/rust/libraries/acars_connection_manager/src/cached_dns_tcp.rs
+++ b/rust/libraries/acars_connection_manager/src/cached_dns_tcp.rs
@@ -25,12 +25,17 @@ use std::ops::Deref;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use sdre_stubborn_io::tokio::UnderlyingIo;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
 
 use crate::dns::{self, Resolver};
+
+/// TCP keepalive idle/interval applied to every (re)connected stream.
+const KEEPALIVE_TIME: Duration = Duration::from_secs(5);
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Context handed to [`CachedDnsTcp::establish`] on every (re)connect.
 #[derive(Clone)]
@@ -60,6 +65,16 @@ impl UnderlyingIo for CachedDnsTcp {
         Box::pin(async move {
             let addr = dns::resolve_host_port(&ctx.resolver, &ctx.host).await?;
             let stream = TcpStream::connect(addr).await?;
+
+            // Apply socket-level configuration here, inside `establish`, so it is
+            // re-applied on every reconnect. `StubbornIo` warns that configuration
+            // applied externally via `Deref` is silently lost on reconnect, which
+            // previously left reconnected sockets with no keepalive at all.
+            let ka = socket2::TcpKeepalive::new()
+                .with_time(KEEPALIVE_TIME)
+                .with_interval(KEEPALIVE_INTERVAL);
+            socket2::SockRef::from(&stream).set_tcp_keepalive(&ka)?;
+
             Ok(Self(stream))
         })
     }
@@ -120,5 +135,41 @@ impl AsyncWrite for CachedDnsTcp {
     }
     fn is_write_vectored(&self) -> bool {
         self.0.is_write_vectored()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::TcpListener;
+
+    /// Regression test: keepalive must be applied inside `establish` so it
+    /// survives reconnects. Previously keepalive was set on the `Deref`'d
+    /// `TcpStream` after `connect_with_options` returned, which `StubbornIo`
+    /// silently discards on every reconnect — and the sender path never set it
+    /// at all. This binds a local listener, runs `establish` directly, and
+    /// asserts the freshly-built stream has `SO_KEEPALIVE` enabled.
+    #[tokio::test]
+    async fn establish_enables_keepalive() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // Accept and hold the peer so the connection stays up for inspection.
+        let accept = tokio::spawn(async move { listener.accept().await.unwrap() });
+
+        let target = ConnectTarget {
+            host: Arc::from(format!("127.0.0.1:{port}").as_str()),
+            resolver: dns::new_shared_resolver(),
+        };
+
+        let stream = CachedDnsTcp::establish(target).await.unwrap();
+
+        let keepalive = socket2::SockRef::from(&stream.0).keepalive().unwrap();
+        assert!(
+            keepalive,
+            "establish must enable SO_KEEPALIVE so it survives reconnects"
+        );
+
+        let _peer = accept.await.unwrap();
     }
 }

--- a/rust/libraries/acars_connection_manager/src/tcp_services.rs
+++ b/rust/libraries/acars_connection_manager/src/tcp_services.rs
@@ -29,7 +29,6 @@ use std::error::Error;
 use std::io;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::broadcast;
@@ -238,14 +237,9 @@ impl TCPReceiverServer {
             }
         };
 
-        // Set TCP KeepAlive. Two derefs: StubbornIo -> CachedDnsTcp -> TcpStream.
-        let sock_ref = socket2::SockRef::from(&**stream);
-
-        let mut ka = socket2::TcpKeepalive::new();
-        ka = ka.with_time(Duration::from_secs(5));
-        ka = ka.with_interval(Duration::from_secs(5));
-
-        sock_ref.set_tcp_keepalive(&ka)?;
+        // TCP keepalive is applied inside `CachedDnsTcp::establish`, so it
+        // survives reconnects (configuration applied here via `Deref` would be
+        // silently lost on reconnect).
 
         // create a buffered reader and send the messages to the channel
 

--- a/rust/libraries/acars_connection_manager/src/udp_services.rs
+++ b/rust/libraries/acars_connection_manager/src/udp_services.rs
@@ -275,7 +275,7 @@ impl UDPSenderServer {
 
                 match bytes_sent {
                     Ok(bytes_sent) => {
-                        debug!("sent {} bytes to {} ({})", bytes_sent, addr, resolved)
+                        debug!("sent {} bytes to {} ({})", bytes_sent, addr, resolved);
                     }
                     Err(e) => {
                         warn!(


### PR DESCRIPTION
## Summary

Originated from investigating elevated `feed.airframes.io` disconnect events in a test-instance log. The disconnects themselves are peer-initiated (only that host, only write-side, instant clean reconnects), but the investigation surfaced a genuine latent bug plus some manifest hygiene.

## Changes

- **fix: TCP keepalive survives reconnect.** Keepalive was applied to the `Deref`'d `TcpStream` *after* `connect_with_options` returned. `StubbornIo` discards `Deref`-applied socket configuration on every reconnect, so reconnected receiver sockets lost keepalive, and the sender path (`feed.airframes.io:5553/5556`) never set it at all. Moved the configuration into `CachedDnsTcp::establish` so it is re-applied on every (re)connect for both paths. Includes a hermetic regression test that fails without the fix.
- **fix: missing semicolon** to satisfy a pre-existing `clippy::semicolon_if_nothing_returned` failure in `udp_services.rs` that was blocking the workspace clippy/test run.
- **chore: remove unused dependencies.** `cargo machete` flagged `zmq` (connection-manager; migrated to the `tmq` wrapper) and `serde`/`serde_json`/`socket2` (the binary, a thin bootstrap). Also removed the orphaned `[workspace.dependencies]` catalog entries (`zmq`, `serde`, and the dead `acars_config` path entry) that no member crate activates.
- **chore: update cargo versions.** `serde_json` 1.0.149 -> 1.0.150, `socket2` 0.6.3 -> 0.6.4.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` (25 tests pass, incl. new keepalive regression test)
- `cargo machete` clean

The keepalive regression test was confirmed to fail without the fix and pass with it.