### PR TITLE
ci: enable the hadolint pre-commit hook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
               inherit system;
               src = ./.;
               check_rust = true;
+              check_docker = true;
               enableXtask = false;
               extraExcludes = [
                 "typos.toml"


### PR DESCRIPTION
## Problem

`check_docker` defaults to `false` in the shared ruleset (`FredSystems/pre-commit-checks`, `check_docker ? false`) and this repo never set it, so the generated pre-commit config carried no `hadolint` hook. There is no hadolint job in the deploy workflow either, so **nothing in CI has ever linted this Dockerfile**.

This came out of a fleet-wide audit prompted by hadolint [#1209](https://github.com/hadolint/hadolint/pull/1209), which extended `DL3025` to fire on `HEALTHCHECK ... CMD` in v2.15.0 (published 2026-07-30T13:39:01Z) and silently broke several sibling repos.

## Changes

One line — no Dockerfile change is needed here:

```diff
               check_rust = true;
+              check_docker = true;
               enableXtask = false;
```

This repo's Dockerfile is **already clean at both versions**, and it declares no `HEALTHCHECK`, `CMD` or `ENTRYPOINT` of its own, so it is unaffected by the `DL3025` extension that the sibling repos needed fixing for:

```console
$ hadolint --config <shared ruleset> Dockerfile     # 2.14.0, the flake.lock pin
rc=0

$ hadolint --config <shared ruleset> Dockerfile     # 2.15.1, current :latest
rc=0
```

It inherits `ENTRYPOINT ["/init"]` from `ghcr.io/sdr-enthusiasts/docker-baseimage:base`, already in exec form, so s6 is PID 1 and `docker stop` reaches it for graceful shutdown.

Enabling the hook closes the coverage gap so any future regression is caught on the PR that introduces it, rather than discovered by an audit.

## Verification

- `nix develop -c pre-commit run --all-files`: **all hooks passed**, including `hadolint`, `clippy` and `rustfmt`. `hadolint` now appears in the run — it did not before this branch, which is the direct evidence the flip took effect
- `nixfmt --check flake.nix`: clean
- hadolint clean at both **2.14.0** (the current `flake.lock` pin) and **2.15.1** (current `:latest`), so this cannot turn `Lint` red now or when a `flake.lock` bump lands 2.15.x
- No hooks bypassed; no `--no-verify`
